### PR TITLE
Issue validations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,6 @@ root = true
 [*.{ps1,psm1}]
 indent_style = space
 indent_size = 4
-charset = utf-utf-8-bom
+charset = utf-8-bom
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.{ps1,psm1}]
+indent_style = space
+indent_size = 4
+charset = utf-utf-8-bom
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/ISSUE_TEMPLATE/kPackageRequest.md
+++ b/.github/ISSUE_TEMPLATE/kPackageRequest.md
@@ -8,7 +8,8 @@ about: Request a package be created that does not currently exist in the Chocola
 
 * Please ensure there is no existing open package request.
 
-* Please ensure the issue title starts with 'RFP - ' - for example 'RFP - Adobe Reader'
+* Please ensure the issue title starts with 'RFP - ' - for example 'RFP - adobe-reader'
+* Please also ensure the issue title matches the identifier you expect the package should be named.
 
 * Please ensure you have both the Software Project URL and the Software Download URL before continuing.
 

--- a/.github/ISSUE_TEMPLATE/kPackageRequest.md
+++ b/.github/ISSUE_TEMPLATE/kPackageRequest.md
@@ -17,11 +17,12 @@ NOTE: Keep in mind we have an etiquette regarding communication that we expect f
 PLEASE REMOVE ALL COMMENTS ONCE YOU HAVE READ THEM.
 
 -->
+
 ## Checklist
 
 - [ ] The package I am requesting does not already exist on https://chocolatey.org/packages;
 - [ ] There is no open issue for this package;
-- [ ] The issue title starts 'RFP - ';
+- [ ] The issue title starts with 'RFP - ';
 - [ ] The download URL is public and not locked behind a paywall / login;
 
 ## Package Details

--- a/.github/ISSUE_TEMPLATE/mMaintainerRequest.md
+++ b/.github/ISSUE_TEMPLATE/mMaintainerRequest.md
@@ -47,7 +47,6 @@ Package URL:
 Package source URL:
 
 <!-- please remove the following section if you are the current maintainer of the package, otherwise fill out the details -->
-<!-- Please also ensure that the date the maintainer was contacted is using the ISO 8601 standard (YYYY-MM-DD) -->
 
-Date the maintainer was contacted:
+Date the maintainer was contacted (in YYYY-MM-DD):
 How the maintainer was contacted:

--- a/.github/ISSUE_TEMPLATE/mMaintainerRequest.md
+++ b/.github/ISSUE_TEMPLATE/mMaintainerRequest.md
@@ -10,7 +10,8 @@ If you have followed the Package Triage Process above and want to request to bec
 
 If you have followed the Package Triage Process above and do not want to request to become the maintainer of a package that you DO NOT MAINTAIN, please continue.
 
-Please ensure the issue title starts with 'RFM - ' - for example 'RFM - Adobe Reader'
+Please ensure the issue title starts with 'RFM - ' - for example 'RFM - adobe-reader'
+Please also ensure that the issue title matches the identifier of the package.
 
 Please ensure you have the package URL from https://chocolatey.org/packages before continuing.
 
@@ -18,8 +19,14 @@ NOTE: Keep in mind we have an etiquette regarding communication that we expect f
 
 PLEASE REMOVE ALL COMMENTS ONCE YOU HAVE READ THEM.
 
+Please remove the 'Current Maintainer' section if you are not the current maintainer of the package,
+otherwise if you are the current maintainer of the package please remove the 'I DON'T Want To Become The Maintainer' section.
+
 -->
+
 ## Current Maintainer
+
+<!-- If you are not confirmed as a known maintainer, you may be asked to take additional steps to confirm your user account -->
 
 - [ ] I am the maintainer of the package and wish to pass it to someone else;
 
@@ -34,8 +41,13 @@ PLEASE REMOVE ALL COMMENTS ONCE YOU HAVE READ THEM.
 
 ## Existing Package Details
 
+<!-- You may leave the URLs empty as long as the issue title matches the identifier of the package -->
+
 Package URL:
 Package source URL:
+
 <!-- please remove the following section if you are the current maintainer of the package, otherwise fill out the details -->
+<!-- Please also ensure that the date the maintainer was contacted is using the ISO 8601 standard (YYYY-MM-DD) -->
+
 Date the maintainer was contacted:
 How the maintainer was contacted:

--- a/.github/workflows/handle-comments.yml
+++ b/.github/workflows/handle-comments.yml
@@ -1,0 +1,74 @@
+﻿name: Handle Comments
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  comments:
+    if: ${{ startsWith(github.event.comment.body, '/') }}
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      success: ${{ steps.commenter.outputs.success }}
+
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - name: Attach/Confirm users
+        if: ${{ startsWith(github.event.comment.body, '/attach') || startsWith(github.event.comment.body, '/confirm') }}
+        run: |
+          Import-Module "${{ github.workspace }}/scripts/validation.psm1"
+          New-UserConnection -commentId ${{ github.event.comment.id }} -repository "${{ github.event.repository.full_name }}"
+        shell: pwsh
+      - name: Detach/remove users
+        if: ${{ startsWith(github.event.comment.body, '/detach') || startsWith(github.event.comment.body, '/remove user') }}
+        run: |
+          Import-Module "${{ github.workspace }}/scripts/validation.psm1"
+          Remove-UserConnection -commentId ${{ github.event.comment.id }} -repository "${{ github.event.repository.full_name }}"
+        shell: pwsh
+      - name: Commit added user
+        if: ${{ startsWith(github.event.comment.body, '/attach') || startsWith(github.event.comment.body, '/confirm') || startsWith(github.event.comment.body, '/detach') || startsWith(github.event.comment.body, '/remove user') }}
+        uses: EndBug/add-and-commit@v4.2.0
+        with:
+          add: scripts/users.json
+          message: |
+            (bot) Updated user configurations
+
+            Co-Authored-By: ${{ github.event.sender.login }} <${{ github.event.sender.login }}@users.noreply.github.com>
+          author_name: github-actions[bot]
+          author_email: github-actions[bot]@users.noreply.github.com
+      - name: Submit comment
+        id: commenter
+        run: |
+          if (Test-Path "${{ github.workspace }}/scripts/comment.txt") {
+            $body = Get-Content "${{ github.workspace }}/scripts/comment.txt" -Encoding utf8NoBOM -Raw
+            Import-Module "${{ github.workspace }}/scripts/validation.psm1"
+            Submit-Comment -issueNumber ${{ github.event.issue.number }} -repository "${{ github.event.repository.full_name }}" -commentBody "$body"
+            "::set-output name=success::$($body -notmatch "permission|not recognize")"
+          }
+        shell: pwsh
+  recheck_pkgs:
+    if: ${{ (needs.comments.outputs.success == 'True' || startsWith(github.event.comment.body, '/recheck')) && github.event.issue.state == 'open' }}
+    runs-on: windows-latest
+    needs: comments
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Becasue comment steps take way shorter time than installing
+      # packages, we can run these in parallel
+    steps:
+      - name: Install needed packages
+        uses: crazy-max/ghaction-chocolatey@v1.2.2
+        with:
+          args: install trid 7zip.portable -y --no-progress
+      - uses: actions/checkout@v2.2.0
+      - name: Pull latest commits
+        run: git pull
+      - name: Validate Issue
+        run: |
+          Import-Module "${{ github.workspace }}\scripts\validation.psm1"
+          if ("${{ github.event.comment.body }}" -match "^/recheck") {
+            Test-NewIssue -commentId ${{ github.event.comment.id }} -repository "${{ github.event.repository.full_name }}"
+          } else {
+            Test-NewIssue -issueNumber ${{ github.event.issue.number }} -repository "${{ github.event.repository.full_name }}"
+          }

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -1,0 +1,23 @@
+﻿name: Validate issue
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+jobs:
+  validation:
+    if: ${{ github.event.issue.state == 'open' }}
+    runs-on: windows-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - name: Install needed packages
+        uses: crazy-max/ghaction-chocolatey@v1.2.2
+        with:
+          args: install trid 7zip.portable -y --no-progress
+      - name: Validate Issue
+        run: |
+          Import-Module "${{ github.workspace }}\scripts\validation.psm1"
+          Test-NewIssue -issueNumber ${{ github.event.issue.number }} -repository "${{ github.event.repository.full_name }}"

--- a/scripts/private/Format-Checkboxes.ps1
+++ b/scripts/private/Format-Checkboxes.ps1
@@ -1,4 +1,4 @@
-function Format-Checkboxes() {
+﻿function Format-Checkboxes() {
     param (
         [Parameter(Mandatory = $true)]
         [IssueData]$issueData,

--- a/scripts/private/Format-Checkboxes.ps1
+++ b/scripts/private/Format-Checkboxes.ps1
@@ -1,0 +1,18 @@
+function Format-Checkboxes() {
+    param (
+        [Parameter(Mandatory = $true)]
+        [IssueData]$issueData,
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData
+    )
+
+    $re = "\[(\s+x|x\s+|\s+x\s+)\]"
+    if ($validationData.newBody) {
+        if ($validationData.newBody -match $re) {
+            Update-ValidationBody @PSBoundParameters -replacement $re, "[x]"
+        }
+    }
+    elseif ($issueData.body -match $re) {
+        Update-ValidationBody @PSBoundParameters -replacement $re, "[x]"
+    }
+}

--- a/scripts/private/Format-Url.ps1
+++ b/scripts/private/Format-Url.ps1
@@ -1,0 +1,70 @@
+<#
+.SYNOPSIS
+    Formats the specified url using the specified parameters hashtable
+.PARAMETER url
+    The url format to use when formatting the result url
+.PARAMETER parameters
+    The parameters to use when replacing tokens in the url.
+.OUTPUTS
+    The formatted Url
+#>
+function Format-Url() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$url,
+        [hashtable]$parameters = @{ }
+    )
+
+    $newUrl = ""
+
+    $insideQuote = $false
+    $lastIndex = 0 
+    $char = ''
+    $checkComma = $true
+    while ($lastIndex -ge 0) {
+        if (!$insideQuote -and ($i = $url.IndexOf('{', $lastIndex)) -gt $lastIndex) {
+            $newUrl += $url.Substring($lastIndex, $i - $lastIndex)
+            $insideQuote = $true
+            $c = $url[$i + 1]
+            if ($c -eq '?' -or $c -eq '+' -or $c -eq '/' -or $c -eq '&') {
+                $char = $c
+                $i++
+            }
+            else { $char = '' }
+            $lastIndex = $i + 1
+            $checkComma = $true
+        }
+        elseif ($insideQuote) { 
+            $name = ''
+            if ($checkComma -and ($i = $url.IndexOf(',', $lastIndex)) -ge $lastIndex) {
+                $name = $url.Substring($lastIndex, $i - $lastIndex)
+            }
+            elseif (($i = $url.IndexOf('}', $lastIndex)) -ge $lastIndex) {
+                $name = $url.Substring($lastIndex, $i - $lastIndex)
+                $insideQuote = $false
+            }
+
+            if ($name -notmatch "^[a-z0-9_]+$") {
+                $checkComma = $false
+            }
+            else {
+                if ($parameters.ContainsKey($name)) {
+                    $newUrl += $char + $parameters[$name]
+                    if ($char -eq '?') { $char = '&' }
+                }
+                
+                if ($i -eq -1) { break; } 
+                $lastIndex = $i + 1
+            }
+        }
+        else {
+            break
+        }
+    }
+
+    if ($lastIndex -ge 0) {
+        $newUrl += $url.Substring($lastIndex)
+    }
+
+    return $newUrl
+}

--- a/scripts/private/Format-Url.ps1
+++ b/scripts/private/Format-Url.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Formats the specified url using the specified parameters hashtable
 .PARAMETER url
@@ -18,7 +18,7 @@ function Format-Url() {
     $newUrl = ""
 
     $insideQuote = $false
-    $lastIndex = 0 
+    $lastIndex = 0
     $char = ''
     $checkComma = $true
     while ($lastIndex -ge 0) {
@@ -34,7 +34,7 @@ function Format-Url() {
             $lastIndex = $i + 1
             $checkComma = $true
         }
-        elseif ($insideQuote) { 
+        elseif ($insideQuote) {
             $name = ''
             if ($checkComma -and ($i = $url.IndexOf(',', $lastIndex)) -ge $lastIndex) {
                 $name = $url.Substring($lastIndex, $i - $lastIndex)
@@ -52,8 +52,8 @@ function Format-Url() {
                     $newUrl += $char + $parameters[$name]
                     if ($char -eq '?') { $char = '&' }
                 }
-                
-                if ($i -eq -1) { break; } 
+
+                if ($i -eq -1) { break; }
                 $lastIndex = $i + 1
             }
         }

--- a/scripts/private/Get-RemoteFile.ps1
+++ b/scripts/private/Get-RemoteFile.ps1
@@ -1,0 +1,33 @@
+﻿<#
+.SYNOPSIS
+    Simple helper file for downloading files from a remote location.
+.PARAMETER url
+    The remote location to use while downloading the file.
+.PARAMETER filePath
+    The Path to where the file should be saved.
+#>
+function Get-RemoteFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [uri]$url,
+        [Parameter(Mandatory = $true)]
+        $filePath
+    )
+
+    try {
+        if (!(Get-Command "Get-Webfile" -ea 0)) {
+            $chocoImported = $true
+            Import-Module "$env:chocolateyInstall/helpers/chocolateyInstaller.psm1"
+        }
+
+        Get-Webfile -Url $url -FileName $filePath
+    }
+    catch {
+        throw $_
+    }
+    finally {
+        if ($chocoImported) {
+            Remove-Module "chocolateyInstaller" -ea 0
+        }
+    }
+}

--- a/scripts/private/Test-ValidFile.ps1
+++ b/scripts/private/Test-ValidFile.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Tests a downloaded file to see if it
     is a valid for the current request.

--- a/scripts/private/Test-ValidFile.ps1
+++ b/scripts/private/Test-ValidFile.ps1
@@ -1,0 +1,43 @@
+<#
+.SYNOPSIS
+    Tests a downloaded file to see if it
+    is a valid for the current request.
+.PARAMETER filePath
+    The path to the downloaded file
+.OUTPUTS
+    A hashtable containing the result
+    of the check, and the output from trid.
+#>
+function Test-ValidFile {
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$filePath
+    )
+
+    if (!(Test-Path $filePath)) { return "missing" }
+    if (!(Get-Command trid -ea 0)) { return "missing" }
+
+    $result = @{}
+
+    # First check if it as an gz file
+    $output = trid $filePath
+    $result["output"] = $output
+    if ($output | Where-Object { $_ -match "100\.0%.*GZipped" }) {
+        if (!(Get-Command 7z -ea 0)) { return "missing" }
+
+        7z e $filePath
+        $filePath = (Get-Item $filePath).BaseName
+        $output = trid $filePath
+        $result["output"] += $output
+    }
+
+    $supportedMatches = @("Executable"; "Windows Installer"; "Archive")
+
+    $result["valid"] = $output | Where-Object {
+        $line = $_
+        $supportedMatches | Where-Object { $line -match $_ }
+    }
+
+    return $result
+}

--- a/scripts/private/api/Get-ApiUrls.ps1
+++ b/scripts/private/api/Get-ApiUrls.ps1
@@ -1,0 +1,38 @@
+﻿class ApiUrls {
+    [string]$collaborators_url;
+    [string]$issue_comment_url;
+    [string]$issue_search_url;
+    [string]$issues_url;
+    [string]$permissions_url;
+    [string]$repository_url;
+}
+
+$apiUrls = $null
+
+<#
+.SYNOPSIS
+    Gets the stored urls known during this session.
+.DESCRIPTION
+    This function gets the stored urls from the current session,
+    or reached out to the github api to get the first basic urls.
+.OUTPUTS
+    A class holding the api urls.
+#>
+function Get-ApiUrls {
+    [OutputType([ApiUrls])]
+    param(
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    if ($apiUrls) {
+        return $apiUrls
+    }
+
+    $response = Invoke-Api -url "https://api.github.com" -githubToken $githubToken | Select-Object issue_search_url, repository_url
+
+    $apiUrls = [ApiUrls]::new()
+    $apiUrls.issue_search_url = $response.issue_search_url
+    $apiUrls.repository_url = $response.repository_url;
+
+    return $apiUrls
+}

--- a/scripts/private/api/Invoke-Api.ps1
+++ b/scripts/private/api/Invoke-Api.ps1
@@ -1,0 +1,58 @@
+﻿<#
+.SYNOPSIS
+    Invokes a single call to the github api using the specified url format.
+.DESCRIPTION
+    Invokes a single call to the github api using the specified url format.
+    This function also allows the url to be formatted with the specified parameters.
+    This function also makes sure that the content (if specified) is correctly serialized
+    to json using Newtonsoft.
+.PARAMETER url
+    The url format to use when calling github.
+.PARAMETER parameters
+    The parameters to use when formatting the url.
+.PARAMETER method
+    The method to use when calling the githb api (Typically, GET, POST, PATCH and DELETE)
+    (Defaults to Get)
+.PARAMETER content
+    The content to submit to the github api (like a comment for instance)
+.PARAMETER githubToken
+    The token to use for authenticated requests (Recommended to be used)
+    (Defaults to $env:GITHUB_TOKEN)
+.OUTPUTS
+    The result of the request.
+#>
+function Invoke-Api() {
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$url,
+        [hashtable]$parameters = @{},
+        [string]$method = "Get",
+        [hashtable]$content = $null,
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    $headers = @{}
+    if ($githubToken) {
+        Write-Verbose "Using Authenticated github reques"
+        $headers["Authorization"] = "token " + $githubToken
+    }
+
+    $formattedUrl = Format-Url $url $parameters
+
+    $arguments = @{
+        Uri             = $formattedUrl
+        Method          = $method
+        Headers         = $headers
+        UseBasicParsing = $true
+    }
+
+    if ($content) {
+        # Workaround since the API don't like a line to end with a space + colon (json parsing error on github)
+        $json = [Newtonsoft.Json.JsonConvert]::SerializeObject($content) -replace "\s+:(\\[rn]|$)", ":`${1}"
+        $arguments["Body"] = $json
+        $arguments["ContentType"] = "application/json"
+    }
+
+    return Invoke-RestMethod @arguments
+}

--- a/scripts/private/api/comments/Add-Comment.ps1
+++ b/scripts/private/api/comments/Add-Comment.ps1
@@ -1,0 +1,45 @@
+﻿<#
+.SYNOPSIS
+    Adds a completely new comment on github.
+.PARAMETER issueNumber
+    The issue number to add the new comment to.
+.PARAMETER repository
+    The repository that the issue is located in.
+.PARAMETER commentBody
+    The actual comment to submit to github.
+.OUTPUTS
+    Returns the created comment
+#>
+function Add-Comment {
+    [OutputType([CommentData])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [int]$issueNumber,
+        [Parameter(Mandatory = $true)]
+        [string]$repository,
+        [Parameter(Mandatory = $true)]
+        [string]$commentBody,
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    $apiUrls = Get-ApiUrls
+
+    if (!$apiUrls.issues_url) {
+        Get-RepositoryData -repository $repository -githubToken $githubToken | Out-Null
+    }
+
+    $arguments = @{
+        url         = $apiUrls.issues_url
+        method      = "POST"
+        githubToken = $githubToken
+        parameters  = @{
+            number = "$issueNumber/comments"
+        }
+        content     = @{
+            body = $commentBody
+        }
+    }
+
+    return Invoke-Api @arguments
+}

--- a/scripts/private/api/comments/CommentData.ps1
+++ b/scripts/private/api/comments/CommentData.ps1
@@ -1,0 +1,8 @@
+﻿class CommentData {
+    [int]$id;
+    [string]$body;
+    [string]$html_url;
+    [string]$issue_url;
+    [string]$url;
+    [string]$userLogin;
+}

--- a/scripts/private/api/comments/Get-Comment.ps1
+++ b/scripts/private/api/comments/Get-Comment.ps1
@@ -1,0 +1,61 @@
+﻿<#
+.SYNOPSIS
+    Gets a single comment on github
+.DESCRIPTION
+    Get a single comment on github by either using the
+    specified commentId parameter, or using content matching
+    to see which comment has the a matching body.
+.PARAMETER commentId
+    The unique identifier of the comment to get.
+.PARAMETER issueNumber
+    The issue number that the comment is located in.
+.PARAMETER contentMatch
+    The regex that should match the body of the comment
+    to return.
+.PARAMETER repository
+    The repository where the comment are located in.
+.OUTPUTS
+    The found comment.
+.NOTES
+    Only the first match of the comment is returned
+    when content matching is used.
+#>
+function Get-Comment() {
+    [OutputType([CommentData])]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = "known comment")]
+        [int]$commentId,
+        [Parameter(Mandatory = $true, ParameterSetName = "matching content")]
+        [int]$issueNumber,
+        [Parameter(Mandatory = $true, ParameterSetName = "matching content")]
+        [string]$contentMatch,
+        [Parameter(Mandatory = $true)]
+        [string]$repository,
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    $apiUrls = Get-ApiUrls
+
+    if (!$apiUrls.issue_comment_url) {
+        Get-RepositoryData -repository $repository -githubToken $githubToken | Out-Null
+    }
+
+    if ($issueNumber) {
+        $comments = Invoke-Api -url $apiUrls.issues_url -parameters @{ number = "$issueNumber/comments" }
+
+        return $comments | Where-Object { $_.body -match $contentMatch } | Select-Object -First 1
+    }
+
+    $response = Invoke-Api -url $apiUrls.issue_comment_url -parameters @{ number = $commentId }
+
+    $result = [CommentData]::new()
+    $result.body = $response.body
+    $result.html_url = $response.html_url
+    $result.id = $response.id
+    $result.issue_url = $response.issue_url
+    $result.url = $response.url
+    $result.userLogin = $response.user.login
+
+    return $result
+}

--- a/scripts/private/api/comments/Invoke-Commenting.ps1
+++ b/scripts/private/api/comments/Invoke-Commenting.ps1
@@ -1,0 +1,33 @@
+﻿<#
+.SYNOPSIS
+    Submits a comment when running locally, stores the comment on github actions
+.DESCRIPTION
+    Small helper function for storing comments to be used later when running on
+    github action, or just submit the comment as is when running locally.
+.PARAMETER issueNumber
+    The issue number to use in the request
+.PARAMETER commentBody
+    The actualy comment to submit/store when calling this function
+#>
+function Invoke-Commenting {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$issueNumber,
+        [Parameter(Mandatory = $true)]
+        $commentBody
+    )
+
+    if (Test-Path Env:\GITHUB_ACTIONS) {
+        $comment = ""
+        if (Test-Path "$PSScriptRoot/../../../comment.txt") {
+            $comment = Get-Content -Encoding utf8NoBOM -Path $comment
+        }
+
+        $comment = "$comment`n$commentBody"
+        Write-Host "Storing comment text for using is github actions later..."
+        $comment | Out-File "$PSScriptRoot/../../../comment.txt" -Encoding utf8NoBOM
+    }
+    else {
+        Submit-Comment -issueNumber $issueNumber -commentBody $commentBody
+    }
+}

--- a/scripts/private/api/comments/Invoke-Commenting.ps1
+++ b/scripts/private/api/comments/Invoke-Commenting.ps1
@@ -14,6 +14,8 @@ function Invoke-Commenting {
         [Parameter(Mandatory = $true)]
         [int]$issueNumber,
         [Parameter(Mandatory = $true)]
+        [string]$repository,
+        [Parameter(Mandatory = $true)]
         $commentBody
     )
 
@@ -28,6 +30,6 @@ function Invoke-Commenting {
         $comment | Out-File "$PSScriptRoot/../../../comment.txt" -Encoding utf8NoBOM
     }
     else {
-        Submit-Comment -issueNumber $issueNumber -commentBody $commentBody
+        Submit-Comment -issueNumber $issueNumber -repository $repository -commentBody $commentBody
     }
 }

--- a/scripts/private/api/comments/Remove-Comment.ps1
+++ b/scripts/private/api/comments/Remove-Comment.ps1
@@ -1,0 +1,29 @@
+﻿<#
+.SYNOPSIS
+    Removes a single comment from the github repository.
+.PARAMETER commentId
+    The unique identifier of the comment to remove
+.PARAMETER repository
+    The repository where the comment is located
+.OUTPUTS
+    $null
+#>
+function Remove-Comment() {
+    [OutputType($null)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$commentId,
+        [Parameter(Mandatory = $true)]
+        [string]$repository,
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    $apiUrls = Get-ApiUrls -githubToken $githubToken
+
+    if (!$apiUrls.issue_comment_url) {
+        Get-RepositoryData -repository $repository -githubToken $githubToken | Out-Null
+    }
+
+    Invoke-Api -url $apiUrls.issue_comment_url -parameters @{ number = $commentId } -method "DELETE" -githubToken $githubToken | Out-Null
+}

--- a/scripts/private/api/comments/Update-Comment.ps1
+++ b/scripts/private/api/comments/Update-Comment.ps1
@@ -1,0 +1,57 @@
+﻿<#
+.SYNOPSIS
+    Updates a single comment on github.
+.DESCRIPTION
+    Updates the comment on github that have the
+    unique identifier specified.
+.PARAMETER commentId
+    The unique identifier of the comment to update
+.PARAMETER repository
+    The repository the comment is located in
+.PARAMETER commentBody
+    The new body of the comment
+.OUTPUTS
+    Returns the updated comment
+#>
+function Update-Comment {
+    [OutputType([CommentData])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$commentId,
+        [Parameter(Mandatory = $true)]
+        [string]$repository,
+        [Parameter(Mandatory = $true)]
+        [string]$commentBody,
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    $apiUrls = Get-ApiUrls
+
+    if (!$apiUrls.issue_comment_url) {
+        Get-RepositoryData -repository $repository -githubToken $githubToken | Out-Null
+    }
+
+    $arguments = @{
+        url         = $apiUrls.issue_comment_url
+        method      = "PATCH"
+        githubToken = $githubToken
+        parameters  = @{
+            number = $commentId
+        }
+        content     = @{
+            body = $commentBody
+        }
+    }
+
+    $response = Invoke-Api @arguments
+
+    $result = [CommentData]::new()
+    $result.body = $response.body
+    $result.html_url = $response.html_url
+    $result.id = $response.id
+    $result.issue_url = $response.issue_url
+    $result.url = $response.url
+    $result.userLogin = $response.user.login
+    return $result
+}

--- a/scripts/private/api/issues/Get-Issue.ps1
+++ b/scripts/private/api/issues/Get-Issue.ps1
@@ -1,0 +1,57 @@
+﻿<#
+.SYNOPSIS
+    Gets a single issue
+.DESCRIPTION
+    Gets a single issue that matches the specified issue number in the
+    specified repository, or by using the specified issue url.
+.PARAMETER issueNumber
+    The issue number of the issue to get
+.PARAMETER issueUrl
+    The api url to the issue to get
+.PARAMETER repository
+    The repository where the issue is located in
+.OUTPUTS
+    The found issue data
+#>
+function Get-Issue() {
+    [OutputType([IssueData])]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = "number")]
+        [int]$issueNumber,
+        [Parameter(Mandatory = $true, ParameterSetName = "url")]
+        [uri]$issueUrl,
+        [Parameter(Mandatory = $true, ParameterSetName = "number")]
+        [string]$repository,
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    if ($issueUrl) {
+        $response = Invoke-Api -url $issueUrl -githubToken $githubToken
+    }
+    else {
+
+        $apiUrls = Get-ApiUrls
+
+        if (!$apiUrls.issues_url) {
+            Get-RepositoryData -repository $repository -githubToken $githubToken | Out-Null
+        }
+
+        $response = Invoke-Api -url $apiUrls.issues_url -parameters @{ number = $issueNumber } -githubToken $githubToken
+    }
+
+    $result = [IssueData]::new()
+
+    $result.assignees = $response.assignees | ForEach-Object login
+    $result.body = $response.body
+    $result.html_url = $response.html_url
+    $result.id = $response.id
+    $result.labels = $response.labels | ForEach-Object name
+    $result.number = $response.number
+    $result.state = $response.state
+    $result.title = $response.title
+    $result.url = $response.url
+    $result.userLogin = $response.user.login
+
+    return $result
+}

--- a/scripts/private/api/issues/IssueData.ps1
+++ b/scripts/private/api/issues/IssueData.ps1
@@ -1,0 +1,18 @@
+﻿enum IssueState {
+    None
+    Open
+    Closed
+}
+
+class IssueData {
+    [int]$id;
+    [string]$url;
+    [string]$html_url;
+    [int]$number;
+    [IssueState]$state;
+    [string]$title;
+    [string]$body;
+    [string]$userLogin;
+    [string[]]$labels;
+    [string[]]$assignees;
+}

--- a/scripts/private/api/issues/Search-Issues.ps1
+++ b/scripts/private/api/issues/Search-Issues.ps1
@@ -1,0 +1,47 @@
+﻿<#
+.SYNOPSIS
+    Search the specified repository for issues
+.DESCRIPTION
+    Searches the specified repository for issues
+    that matches the specified query
+.PARAMETER query
+    The query to use when searching for issues.
+.PARAMETER repository
+    The repository to execute the search inside.
+.OUTPUTS
+    An array of issue datas matching the search query
+#>
+function Search-Issues {
+    [OutputType([IssueData[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$query,
+        [Parameter(Mandatory = $true)]
+        [string]$repository,
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    $apiUrls = Get-ApiUrls
+
+    if (!$apiUrls.issue_search_url) {
+        Get-RepositoryData -repository $repository -githubToken $githubToken | Out-Null
+    }
+
+    $result = Invoke-Api -url $apiUrls.issue_search_url -parameters @{ query = $query }
+
+    return $result.items | % {
+        $item = [IssueData]::new()
+        $item.assignees = $_.assignes | % login
+        $item.body = $_.body
+        $item.html_url = $_.html_url
+        $item.id = $_.id
+        $item.labels = $_.labels | % name
+        $item.number = $_.number
+        $item.state = $_.state
+        $item.title = $_.title
+        $item.url = $_.url
+        $item.userLogin = $_.user.login
+        $item
+    }
+}

--- a/scripts/private/api/issues/Update-Issue.ps1
+++ b/scripts/private/api/issues/Update-Issue.ps1
@@ -1,0 +1,94 @@
+﻿<#
+.SYNOPSIS
+    Updates a single issue
+.DESCRIPTION
+    Updates a single issue with either the matching issue
+    number and located in the specified repository, or using
+    the full api url for issues.
+.PARAMETER issueNumber
+    The issue number of the issue to update.
+.PARAMETER repository
+    The repository where the issue is located in.
+.PARAMETER issueurl
+    The full api url for the issue
+.PARAMETER title
+    The new title of the issue
+.PARAMETER description
+    The new description/body of the issue
+.PARAMETER assignees
+    The people that should be assigned to this issue
+.PARAMETER labels
+    The labels that should be set on the issue (will override existing labels)
+.PARAMETER state
+    The state of the issue (typically Open or closed)
+.PARAMETER githubToken
+    The token to use for authenticated requests
+.OUTPUTS
+    Returns the updated issue data
+#>
+function Update-Issue() {
+    [OutputType([IssueData])]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = "number")]
+        [int]$issueNumber,
+        [Parameter(Mandatory = $true, ParameterSetName = "number")]
+        [string]$repository,
+
+        [Parameter(Mandatory = $true, ParameterSetName = "url")]
+        [string]$issueUrl,
+
+        [string]$title,
+        [string]$description,
+        [string[]]$assignees,
+        [string[]]$labels,
+        [IssueState]$state = 'None',
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    if (!$title -and !$description -and !$assignees -and !$labels) {
+        throw "Not valid data was used to update the issue. A title, description, assignees or labels is required."
+    }
+
+    if ($issueUrl) {
+        $existingIssue = Get-Issue -issueUrl $issueUrl -githubToken $githubToken
+    }
+    else {
+        $existingIssue = Get-Issue -issueNumber $issueNumber -repository $repository -githubToken $githubToken
+    }
+
+    $content = @{}
+
+    if ($title) {
+        $content['title'] = $title
+    }
+    if ($description) {
+        $content['body'] = $description
+    }
+    if ($assignees) {
+        $content['assignees'] = $assignees
+    }
+    if ($labels) {
+        $content['labels'] = $labels
+    }
+    if ($state -ne 'None' -and $state -ne $existingIssue.state) {
+        $content['state'] = $state
+    }
+
+    $response = Invoke-Api -url $existingIssue.url -parameters @{ number = $issueNumber } -method "PATCH" -content $content -githubToken $githubToken
+
+    $result = [IssueData]::new()
+
+    $result.assignees = $response.assigees | ForEach-Object login
+    $result.body = $response.body
+    $result.html_url = $response.html_url
+    $result.id = $response.id
+    $result.labels = $response.labels | ForEach-Object name
+    $result.number = $response.number
+    $result.state = $response.state
+    $result.title = $response.title
+    $result.url = $response.url
+    $result.userLogin = $response.user.login
+
+    return $result
+}

--- a/scripts/private/api/permissions/Get-Permission.ps1
+++ b/scripts/private/api/permissions/Get-Permission.ps1
@@ -1,0 +1,50 @@
+﻿class PermissionData {
+    [string]$login;
+    [bool]$readAccess;
+    [bool]$writeAccess;
+    [bool]$adminAccess;
+}
+
+<#
+.SYNOPSIS
+    Gets the permissions set for the specified login name
+.PARAMETER login
+    The login/username of the user to get the repository permissions for.
+.PARAMETER repository
+    The repository to use.
+.PARAMETER githubToken
+    The token to use for authenticated requests
+.OUTPUTS
+    Returns the available permissions for the user
+#>
+function Get-Permission() {
+    [OutputType([PermissionData])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$login,
+
+        [Parameter(Mandatory = $true)]
+        [string]$repository,
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    $apiUrls = Get-ApiUrls
+
+    if (!$apiUrls.permissions_url) {
+        Get-RepositoryData -repository $repository -githubToken $githubToken | Out-Null
+    }
+
+    $response = Invoke-Api -url $apiUrls.permissions_url -parameters @{ collaborator = $login }
+
+    $permissionData = [PermissionData]::new()
+
+    if ($response) {
+        $permissionData.login = $response.user.login
+        $permissionData.adminAccess = $response.permission -eq 'admin'
+        $permissionData.writeAccess = $permissionData.adminAccess -or $response.permission -eq 'write' -or $permissionData.permission -eq 'maintainer' # Maintainer is never returned, but maybe in the future
+        $permissionData.readAccess = $permissionData.writeAccess -or $response.permission -eq 'read' -or $permissionData.permission -eq 'triage' # Triage is never returned, but maybe in the future
+    }
+
+    return $permissionData
+}

--- a/scripts/private/api/repository/Get-RepositoryData.ps1
+++ b/scripts/private/api/repository/Get-RepositoryData.ps1
@@ -1,0 +1,64 @@
+﻿class RepositoryData {
+    [int]$id;
+    [string]$name;
+    [string]$full_name;
+    [string]$html_url;
+    [string]$description;
+    [string]$url;
+    [string]$collaborators_url;
+    [string]$issue_comment_url;
+    [string]$issues_url;
+}
+
+<#
+.SYNOPSIS
+    Gets information about a single repository
+.PARAMETER repoOwner
+    The owner of the repository
+.PARAMETER repoName
+    The name of the repository
+.PARAMETER repository
+    The full name of the repository (owner/name)
+.PARAMETER githubToken
+    The api token to use for authenticated requests
+.OUTPUTS
+    The gathered repository data information
+#>
+function Get-RepositoryData() {
+    [OutputType([RepositoryData])]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = "repo+owner")]
+        [string]$repoOwner,
+
+        [Parameter(Mandatory = $true, ParameterSetName = "repo+owner")]
+        [string]$repoName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = "repository")]
+        [string]$repository,
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    $apiUrls = Get-ApiUrls -githubToken $githubToken
+
+    if ($repository) {
+        $repoSplits = $repository -split '\/'
+        $repoOwner = $repoSplits[0]
+        $repoName = $repoSplits[1]
+    }
+
+    [RepositoryData]$repositoryData = Invoke-Api -url $apiUrls.repository_url -parameters @{ owner = $repoOwner; repo = $repoName } | Select-Object -Property id, name, full_name, html_url, description, url, collaborators_url, issue_comment_url, issues_url
+
+    if (!$apiUrls.collaborators_url) {
+        $apiUrls.collaborators_url = $repositoryData.collaborators_url
+        $apiUrls.permissions_url = Format-Url -url $apiUrls.collaborators_url -parameters @{ collaborator = "{collaborator}/permission" }
+    }
+    if (!$apiUrls.issue_comment_url) {
+        $apiUrls.issue_comment_url = $repositoryData.issue_comment_url
+    }
+    if (!$apiUrls.issues_url) {
+        $apiUrls.issues_url = $repositoryData.issues_url
+    }
+
+    return $repositoryData
+}

--- a/scripts/private/messages.ps1
+++ b/scripts/private/messages.ps1
@@ -1,0 +1,187 @@
+﻿class ErrorMessages {
+    static [string]$invalidCommand = "I am sorry @{0}, but we did not recognize that command";
+    static [string]$invalidCommandException = "We could not extract a valid command from the comment";
+    static [string]$toolingMissing = "Some tooling is missing from the CI system, please make sure everything is installed (7zip and trid currently required).";
+}
+
+class PermissionMessages {
+    static [string]$actionDenied = "I am sorry @{0}, but you do not seem to have permission to make this action!";
+    static [string]$userAddDenied = "I am sorry @{0}, but you do not seem to have permission to add other users.";
+    static [string]$userRemoveDenied = "I am sorry @{0}, but you do not seem to have permission to remove other users.";
+    static [string]$issueUserAssigned = "@{0} a user have already been assigned to this issue. Validation will not run when a user is assigned.";
+    static [string]$issueLabelAssigned = "@{0} this issue have been labeled. Validation will only run on unlabeled, labeled with {1} or with {2} issues.";
+}
+
+class StatusCheckMessages {
+    static [string]$checkingExistingValidationComment = "Checking for comments already submitted by the package request validator...";
+    static [string]$checkingForExistingIssues = "Checking for other issues matching {0}"
+    static [string]$checkingUserMarkedChocolateySearched = "Checking if user have searched for packages on chocolatey.org";
+    static [string]$checkingUserMarkedDownloadUrlPublic = "Checking if user have marked the download URL as being public and not bedind a paywall";
+    static [string]$checkingUserProvidedDirectDownloadUrl = "Checking if the user have provided a direct download URL";
+    static [string]$checkingUserProvidedSoftwareProjectUrl = "Checking if user have provided a URL to the software project";
+    static [string]$checkingUserSearchedForOpenIssues = "Checking if the user have checked for already opened issues";
+    static [string]$checkingValidMaintainerHeaderUsed = "Checking that the user have selected either Current Maintainer or that he/she don't want to become the maintainer.";
+    static [string]$checkMarkedAsCurrentMaintainer = "Checking if the user have selected that they are the current maintainer";
+    static [string]$checkMarkedAsFollowingTriageProcess = "Checking if user have marked that they have followed the Package Triage Process";
+    static [string]$checkMarkedAsSearchedForIssues = "Checking if the user have marked that they have checked for existing issues";
+    static [string]$checkPackageExistOnChocolatey = "Checking chocolatey.org for an existing package named {0}";
+    static [string]$checkUserMarkedWithCorrectRFMTitle = "Checking if the user have marked the issue with RFM";
+    static [string]$checkUserMarkedWithCorrectRFPTitle = "Checking if the user have marked the issue with RFP";
+    static [string]$checkUserProvidedPackageSourceUrl = "Checking if the user have added the url to the package source";
+    static [string]$checkUserProvidedPackageUrl = "Checking if the user have added the url to the package";
+    static [string]$checkUserRemovedMaintainerContactedDate = "Checking if the user have removed the 'Date the maintainer was contacted' part";
+    static [string]$checkUserRemovedMaintainerContactedMethod = "Checking if the user have removed the 'How the maintainer was contacted' part";
+    static [string]$checkUserSuppliedMaintainerContactDate = "Checking if the user have added the date he/she contacted the current maintainer";
+    static [string]$checkUserSuppliedMaintainerContactMethod = "Checking if the user have addded how he/she contacted the current maintainer";
+    static [string]$creatingValidationComment = "Creating new comment with parsed validation data...";
+    static [string]$existingValidationCommentFound = "Existing comment was found. Removing existing comment...";
+    static [string]$fileDownloadCheck = "Downloading file from direct download URL for testing.";
+    static [string]$fileDownloadedTest = "Testing downloaded file";
+    static [string]$issueUsesRFPOrRFMTitle = "Checking if user have prefixed title withe RFP or RFM";
+}
+
+class StatusMessages {
+    static [string]$bodyNotMatchingUpdating = "Body do not match with recommendation, updating...";
+    static [string]$chocolateyUserConfirmed = "@{0} thank you for confirming your chocolatey username. You are now connected to the [{1}](https://chocolatey.org/profiles/{1}) chocolatey user.";
+    static [string]$chocolateyUserConnected = "Chocolatey user [{0}](https://chocolatey.org/packages/{0}) has been connected to the github user @{1}";
+    static [string]$chocolateyUserDisconnected = "Connected chocolatey user [{0}](https://chocolatey.org/profiles/{0}) have been removed.";
+    static [string]$githubUserDisconnected = "Connected github user @{0} have been removed";
+    static [string]$issueHaveBeenLabeled = "The issue have been labeled with a status label, thus no longer needing validation";
+    static [string]$packageFoundOnChocolatey = "Package found, checking if package is listed.";
+    static [string]$packageNotFoundForRFP = "Information did not find a package matching {0}. This is correct in this case for RFP requests.";
+    static [string]$packageSourceUrlFound = "User did not provide a package source url, but a url was found. Updating...";
+    static [string]$packageUrlFound = "Found empty Package URL in the body and a package that matches the title. Updating the body to reflect this package url";
+    static [string]$requestingIssue = "Requesting issue #{0}...";
+    static [string]$titleNotMatchingUpdating = "Title do not match with recommendation, updating...";
+    static [string]$uncheckedRFMItemFound = "Found unchecked RFM item, but title contains/will be changed to RFM. Updating issue body to reflect this.";
+    static [string]$uncheckedRFPItemFound = "Found unchecked RFP item, but title contains/will be changed to RFP. Updating issue body to reflect this.";
+    static [string]$userAssignedToIssue = "A user have been assigned to the issue, no need to do any validation of this request.";
+    static [string]$userNotMarkedRFMTitleCorrectly = "User have not marked that he/she have prefixed the issue title with RFM";
+    static [string]$userNotMarkedRFPTitleCorrectly = "User have not marked that he/she have prefixed the issue title with RFP";
+    static [string]$userNotProvidedPackageSourceUrl = "User seems to not have provided any URL to the package source (or one do not exist).";
+    static [string]$userNotProvidedPackageUrl = "User seems to not have provided any URL to the package";
+}
+
+class StatusLabels {
+    static [string]$statusLabelPrefix = "Status:"
+    static [string]$availableRequest = "Status: Available For Maintainer(s)";
+    static [string]$incompleteRequest = "Status: Incomplete Request";
+    static [string]$triageRequest = "Status: Triage";
+    static [string]$upstreamBlocked = "Blocked Upstream";
+}
+
+class ValidationMessages {
+    static [string]$commentBodyDetection = "<!-- Package Request Validation -->";
+    static [string]$commentBodyHeader = "## Package Request Validation`nWe have finished some basic validation of this request. The result of this validation can be found below:";
+
+    # Success
+    static [string]$availableSuccess = "Everything looks good in our book. This issue is now open to other maintainers.";
+    static [string]$triageSuccess = "Everything looks good to our automated checks, it is now up to a human to validate the remaining steps. No action is required yet";
+
+    # Errors detected for request header
+    static [string]$errorsHeader = "### Request Issues to fix`n`n**We have found the following issues with this request. Please update the issue to reflect any necessary changes mentioned.**`n`n";
+
+    # Notices detected for request header
+    static [string]$noticesHeader = "### Request Notices`n`n**We found some issues we could not fully validate without user input, or by human review. Please make any necessary changes when appropriate.**`n`n";
+
+    # Messages for any maintainers that would pick up this request header
+    static [string]$maintainersHeader = "### New Maintainer Notices`n`nThis section details some parts of the request that any upcoming maintainer may need to take into consideration.`n`n";
+
+    # Generic message about this check being in alpha
+
+    static [string]$commentBodyFooter = "`n`n**Please note that this check is currently in alpha, and may not be able to detect everything correctly.`nHumans may also be able to detect other issues with this request.**";
+    static [string]$invalidRequestType = "We could not parse the request type. Please ensure that the issue title starts with RFM or RFP and is in the following format: ``RF[MP] - package-id``";
+    static [string]$packageExistsError = "Is this the package that you are requesting: https://chocolatey.org/packages/{0}? If this is not the package you are looking for, please update the issue title to something else that won't conflict with existing packages on chocolatey.org.";
+    static [string]$packageExistsUnlistedError = "Is this the package you are requesting: https://chocolatey.org/packages/{0}. There is no listed versions, which means it do not show up during a search on chocolatey.org. If this is not the package you are looking for, please update the issue title to something else that won't conflict with existing packages on chocolatey.org.";
+    static [string]$packageNotFoundError = "We could not find a package named {0}. Please verify that the issue title contains the id of the package, with the correct formatting.";
+
+    # General validation messages
+    static [string]$useCorrectTitleError = "Please update the title to start with RFP (Request For new Package) or RFM (Request For new Maintainer).";
+    static [string]$userRequestedIssueWithEmptyBodyError = "We detected that an empty body have been used for this issue request, we have updated the issue with the default body for your type of request. Please update the issue by filling in all the necessary data the template asks.";
+
+    # New package request validation messages
+
+    static [string]$chocolateySearchNotMarkedError = "We could not detect that you have marked that you have tried to search for the package on chocolatey.org yet. If you have not tried to search for the package, please do so now; Otherwise update the issue.";
+    static [string]$downloadUrlPublicMarkedError = "We could not detect that you have marked the download URL as public and it is not hidden behind a paywall. Please note that if the download is private, or if it is hidden behind a paywall, then a package can not be created by the community. The only way to have a package for this in these cases is to contact the developers of the software.";
+    static [string]$fileValidationFailed = "We were unable to find a supported binary file in the download URL. Please make sure that the download URL is correct.";
+    static [string]$fileValidationMaintainerNotice = "We were unable to directly download the provided software from the specified URL, additional work **may** be needed.";
+    static [string]$githubSearchNotMarkedError = "We could not detect that you have already searched for [open issues](https://github.com/{0}/issues?q=is:issue+is:open+in:title+{1}) for this package. Please do so before opening new issues (it will lessen the burdon on those responsible for this repository).";
+    static [string]$issuesFoundNotice = "We found the following open issues that may already match your request: {0}";
+    static [string]$softwareDirectDownloadError = "We could not detect a direct download URL for the software, please add this to the *'Direct Download'* part of the template. If there is no direct download, thene there **may** not be possible to create a package for this request, and would require you to contact the software in this case to have a package.";
+    static [string]$softwareProjectUrlError = "We could not detect that you have provided a URL to the software project site, please add this to the *'Software project URL:'* part of the template.";
+
+    # General new maintainer request validation messages
+
+    static [string]$bothMaintainerSectionsUsedError = "We found both a section for the current maintainer and the one section for those not being the current maintainer being used. If you are not the current maintainer of the package, please remove the section with the header ``### Current Maintainer``. If you are the current maintainer, please remove the section with the header ``### I DON'T Want To Become The Maintainer``. We have stopped remaining validation, and will continue the validation check when you have updated the issue.";
+    static [string]$issueMissingRfmCheckboxError = "We could not detect a checkbox that says you have started the issue with RFM. Please add this item to the issue if it is missing.";
+    static [string]$issueMissingRfpCheckboxError = "We could not detect a checkbox that says you have started the issue with RFP. Please add this item to the issue if it is missing.";
+    static [string]$packageSourceUrlMissingNotice = "We could not detect that you have specified the url to the source of the package. If there is no package source available, then you can safely ignore this message. If there is a package source available, then please add this url to the *'Package source URL:'* part of the issue.";
+    static [string]$packageUrlMissingError = "We could not detect that you have specified a URL to the package in this issue, and we were not able to locate any package matching the id in the issue title. Please update the issue title to match the package name, or add the URL to the *'Package URL:'* part of the issue.";
+
+    # Current maintainer validation messages
+
+    static [string]$currentMaintainerCheckboxMissingError = "We was able to verify that you are the maintainer of the package, however we could not detect this being mentioned in the issue. Please add the template checkbox for confirming that you are the current maintainer.";
+    static [string]$currentMaintainerNotVerifiedUserIsKnownError = "We could not verify that you are a known maintainer of this package. We did find that you are a known user under a different chocolatey username. Please replace the ``Current Maintainer`` section with the template for ``I DON'T Want To Become The Maintainer`` section.";
+    static [string]$currentMaintainerNotVerifiedUserIsUnknownError = "We could not verify that you are a known maintainer of this package. We also do not know which username your github account is associated with. Please add a comment with ``/confirm your-chocolatey-username`` to confirm and associate your github account with a chocolatey user, or replace the ``Current Maintainer`` section with the template for ``I DON'T Want To Become The Maintainer`` section.";
+
+    # Not current maintainer validation messages
+
+    static [string]$maintainerContactedDateMissingError = "We could not detect when you contacted the maintainer. Please add this information to the *'Date the maintainer was contacted:'* part of the template in the format of ``year-month-day`` (example with current date ``$(Get-Date -Format 'yyy-MM-dd')``.";
+    static [string]$maintainerContactedMethodMissingError = "We could not detect how you contacted the maintainer. Please add this information to the `'How the maintainer was contacted'* part of the template.";
+    static [string]$triageProcessNotFollowedError = "We could not detect that you have completed the Package Triage Process for this request. Please head over to the [Package Triage Process documentation](https://chocolatey.org/docs/package-triage-process#the-triage-process) and come back to this request when you have completed the process.";
+}
+
+class WarningMessages {
+    static [string]$chocolateyUserConnected = "The chocolatey user [{0}](https://chocolatey.org/profiles/{0}) have already been connected to a github user.";
+    static [string]$chocolateyUserMissing = "The user {0} do not exist on https://chocolatey.org. Make sure there is no typo in the username.";
+    static [string]$downloadValidationFailed = "Downloading or file validation failed...";
+    static [string]$exitingValidation = "Exiting validation.";
+    static [string]$fileValidationFailed = "File validation failed. No supported binary type was found.";
+    static [string]$githubUserConnected = "The github user {0} have already been connected to a chocolatey user.";
+    static [string]$noDownloadUrlFound = "There was no direct download URL found to download and validate the binary file.";
+    static [string]$templateMissingPackageUrlAndNoPackageMatchesTitle = "Could not detect a place in the issue body for the package url and no package was found to match the title.";
+    static [string]$templateMissingRFMCheckbox = "We was unable to find a checkbox that reflects that the issue starts with RFM.";
+    static [string]$templateMissingRFPCheckbox = "We was unable to find a checkbox that reflects that the issue starts with RFP.";
+    static [string]$userIsKnowMaintainerMissingConfirmationPart = "User is the known maintainer of the package, but issue is missing the part that confirms this.";
+    static [string]$userNotKnownMaintainerOfPackage = "User is not known as the maintainer of the package";
+    static [string]$userNotRemovedMaintainerContactedDate = "User have forgotten to remove the 'Maintainer contacted date part', we'll try removing it";
+    static [string]$userNotRemovedMaintainerContactMethod = "User have forgotten to remove the 'Maintainer contacted part', we'll try removing it";
+    static [string]$userNotSelectedSearchingForIssues = "User have not checked that there is no open maintainer request for this issue request";
+    static [string]$userNotSelectedTriageProcessFollowed = "User have not checked that he/she have followed the package triage process";
+    static [string]$userNotSpecifiedContactDateOfMaintainer = "User did not provide the date the maintainer was contacted in a parsable format";
+    static [string]$userNotSpecifiedContactMethodOfMaintainer = "User did not provide the method of contact on how the maintainer was contact.";
+    static [string]$userNotSpecifiedCorrectRequestTitle = "User have not correctly used RFP or RFM in the issue title";
+    static [string]$userRequestedNewMaintainer = "User mentioned this is a request for new maintainer, but no package was found";
+    static [string]$userRequestedNewPackage = "User requested a new package to be created, but one was already found matching {0}";
+    static [string]$userUsedBothCurrentMaintainerAndCommunityUserTemplate = "The user have used the sections for both the current maintainer, and the one for community users.";
+    static [string]$userRequestedIssueWithEmptyBody = "The user have posted a new request with an empty body.";
+}
+
+
+function Write-WarningMessage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$message
+    )
+
+    if (Test-Path Env:\GITHUB_ACTIONS) {
+        Write-Host "::warning ::$message"
+    }
+    else {
+        Write-Warning $message
+    }
+}
+
+function Write-ErrorMessage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$message
+    )
+
+    if (Test-Path Env:\GITHUB_ACTIONS) {
+        Write-Host "::error ::$message"
+    }
+    else {
+        Write-Error $message
+    }
+}

--- a/scripts/private/validations/Add-ValidationMessage.ps1
+++ b/scripts/private/validations/Add-ValidationMessage.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Add a single validation message to the validation data storage.
 .PARAMETER validationData

--- a/scripts/private/validations/Add-ValidationMessage.ps1
+++ b/scripts/private/validations/Add-ValidationMessage.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Add a single validation message to the validation data storage.
+.PARAMETER validationData
+    The validation data storage to add the message to
+.PARAMETER message
+    The validation message to add
+.PARAMETER type
+    The type of the validation message
+#>
+function Add-ValidationMessage() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData,
+        [Parameter(Mandatory = $true)]
+        [string]$message,
+        [Parameter(Mandatory = $true)]
+        [MessageType]$type
+    )
+
+    $validationMessage = [ValidationMessage]::new()
+    $validationMessage.message = $message
+    $validationMessage.type = $type
+
+    if (!$validationData.messages) {
+        $validationData.messages = [System.Collections.Generic.List[ValidationMessage]]::new()
+    }
+
+    $validationData.messages.Add($validationMessage)
+}

--- a/scripts/private/validations/Compare-Body.ps1
+++ b/scripts/private/validations/Compare-Body.ps1
@@ -1,4 +1,4 @@
-function Compare-Body {
+﻿function Compare-Body {
     param (
         [Parameter(Mandatory = $true)]
         [IssueData]$issueData,

--- a/scripts/private/validations/Compare-Body.ps1
+++ b/scripts/private/validations/Compare-Body.ps1
@@ -1,0 +1,21 @@
+function Compare-Body {
+    param (
+        [Parameter(Mandatory = $true)]
+        [IssueData]$issueData,
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData,
+        [Parameter(Mandatory = $true)]
+        [string]$re
+    )
+
+    if ($validationData.newBody) {
+        $res = $validationData.newBody -match $re | Out-Null
+    }
+    else {
+        $res = $issueData.body -match $re
+    }
+
+    if ($res) {
+        return $Matches
+    }
+}

--- a/scripts/private/validations/Get-CommonMaintainerValidationResults.ps1
+++ b/scripts/private/validations/Get-CommonMaintainerValidationResults.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates the current request as a maintainer request
 .PARAMETER issueData

--- a/scripts/private/validations/Get-CommonMaintainerValidationResults.ps1
+++ b/scripts/private/validations/Get-CommonMaintainerValidationResults.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+    Validates the current request as a maintainer request
+.PARAMETER issueData
+    The issue data for the current request
+.PARAMETER validationData
+    The validation data storage for the current request
+.OUTPUTS
+    Returns $false if validator should abort further processing, otherwise $true
+#>
+function Get-CommonMaintainerValidationResult() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IssueData]$issueData,
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData
+    )
+
+    Write-Host ([StatusCheckMessages]::checkingValidMaintainerHeaderUsed)
+    $currentMaintainer = $issueData.body -match "#\s*Current Maintainer"
+    $notMaintainer = $issueData.body -match "#\s*I DON'T Want To Become The Maintainer"
+
+    if ($currentMaintainer -and $notMaintainer) {
+        Write-WarningMessage ([WarningMessages]::userUsedBothCurrentMaintainerAndCommunityUserTemplate)
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::bothMaintainerSectionsUsedError) -type ([MessageType]::Error)
+        return $false
+    }
+
+    $compareData = @{
+        issueData      = $issueData
+        validationData = $validationData
+    }
+
+    Write-Host ([StatusCheckMessages]::checkUserMarkedWithCorrectRFMTitle)
+    $re = "(?i)\[[\sx]*\]\s*(Issue title starts with 'RFM)"
+    if ((Compare-Body @compareData -re $re) -and ($issueData.title -match "^RFM" -or $validationData.newTitle -match "^RFM")) {
+        Write-Host ([StatusMessages]::uncheckedRFMItemFound)
+        Update-ValidationBody -issueData $issueData -validationData $validationData -replacement $re, "[x] `${1}"
+    }
+    else {
+        Write-WarningMessage ([WarningMessages]::templateMissingRFMCheckbox)
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::issueMissingRfmCheckboxError) -type ([MessageType]::Error)
+    }
+
+    Write-Host ([StatusCheckMessages]::checkUserProvidedPackageUrl)
+    $re = "(?smi)^\s*Package URL\s*\:\s*https\:\/\/chocolatey\.org\/packages\/([^\s\r\n]+)"
+    if (!(Compare-Body @compareData -re $re)) {
+        Write-Host ([StatusMessages]::userNotProvidedPackageUrl)
+        $re = "(?smi)^\s*(Package URL)\s*:[^\r\n]*" # We want to replace the whole line
+        if ((Compare-Body @compareData -re $re) -and $validationData.packageFound) {
+            Update-ValidationBody -issueData $issueData -validationData $validationData -replacement $re, "`${1}: https://chocolatey.org/packages/$($validationData.packageName)"
+        }
+        else {
+            Write-WarningMessage ([WarningMessages]::templateMissingPackageUrlAndNoPackageMatchesTitle)
+            Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+            Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::packageUrlMissingError) -type ([MessageType]::Error)
+        }
+    }
+
+    Write-Host ([StatusCheckMessages]::checkUserProvidedPackageSourceUrl)
+    $re = "(?smi)^\s*Package source URL\s*\:\s*(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*))"
+    if (!(Compare-Body @compareData -re $re)) {
+        Write-Host ([StatusMessages]::userNotProvidedPackageSourceUrl)
+        $re = "(?smi)^\s*(Package source URL)\s*:[^\r\n]*"
+        if ((Compare-Body @compareData -re $re) -and $validationData.packageSourceUrl) {
+            Write-Host ([StatusMessages]::packageSourceUrlFound)
+            Update-ValidationBody -issueData $issueData -validationData $validationData -replacement $re, "`${1}: $($validationData.packageSourceUrl)"
+        }
+        else {
+            Update-StatusLabel -validationData $validationData -label ([StatusLabels]::triageRequest)
+            Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::packageSourceUrlMissingNotice) -type ([MessageType]::Warning)
+        }
+    }
+
+    if ($currentMaintainer) {
+        return Get-CurrentMaintainerValidationResult @PSBoundParameters
+    }
+    else {
+        return Get-CommunityMaintainerValidationResults @PSBoundParameters
+    }
+}

--- a/scripts/private/validations/Get-CommonValidationResults.ps1
+++ b/scripts/private/validations/Get-CommonValidationResults.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates the current request using common rules
 .PARAMETER issueData

--- a/scripts/private/validations/Get-CommonValidationResults.ps1
+++ b/scripts/private/validations/Get-CommonValidationResults.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+    Validates the current request using common rules
+.PARAMETER issueData
+    The issue data for the current request
+.PARAMETER validationData
+    The validation data storage for the current request
+#>
+function Get-CommonValidationResults() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IssueData]$issueData,
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData
+    )
+
+    $title = $issueData.title -replace "^RFP\s*[\-:]\s*", "RFP - " -replace "^RFM\s*[\-:]\s*", "RFM - "
+    $result = $title -match "^RF([PM])\s*-\s*(.+)$"
+
+    if (!$result) {
+        Write-WarningMessage ([WarningMessages]::userNotSpecifiedCorrectRequestTitle)
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::useCorrectTitleError) -type ([MessageType]::Error)
+        return $false
+    }
+    if ($issueData.title -cne $title) {
+        $validationData.newTitle = $title
+    }
+    $validationData.isNewPackageRequest = $Matches[1] -eq 'P'
+    $validationData.packageName = $Matches[2]
+
+    if (!$issueData.body) {
+        Write-WarningMessage ([WarningMessages]::userRequestedIssueWithEmptyBody)
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        $templatesDirectory = "$PSScriptRoot/../../../.github/ISSUE_TEMPLATE"
+        if ($validationData.isNewPackageRequest) {
+            $templateContent = Get-Content -Path "$templatesDirectory/mMaintainerRequest.md" -Encoding utf8NoBOM | Select-Object -Skip 4 | Join-String -Separator "`n"
+        }
+        else {
+            $templateContent = Get-Content -Path "$templatesDirectory/kPackageRequest.md" -Encoding utf8NoBOM | Select-Object -Skip 4 | Join-String -Separator "`n"
+        }
+
+        $validationData.newbody = $templateContent
+
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::userRequestedIssueWithEmptyBodyError) -type ([MessageType]::Error)
+
+        return $false
+    }
+
+    try {
+        Write-Host ([StatusCheckMessages]::checkPackageExistOnChocolatey -f $validationData.packageName)
+        $chocolateyPage = Invoke-WebRequest -Uri ("https://chocolatey.org/packages/{0}" -f $validationData.packageName) -UseBasicParsing
+        $validationData.packageFound
+
+        Write-Host ([StatusMessages]::packageFoundOnChocolatey)
+
+        $allListedLinks = $chocolateyPage.Links | Where-Object { $_.href -match "^\/packages\/$($validationData.packageName)\/" -and $_.href -notmatch "Contact(Admins|Owners)$|ReportAbuse$" }
+        if ($validationData.isNewPackageRequest) {
+            Write-WarningMessage ([WarningMessages]::userRequestedNewPackage -f $validationData.packageName)
+            Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+            if (!$allListedLinks) {
+                $newMsg = [ValidationMessages]::packageExistsUnlistedError
+            }
+            else {
+                $newMsg = [ValidationMessages]::packageExistsError
+            }
+            Add-ValidationMessage -validationData $validationData -message ($newMsg -f $validationData.packageName) -type ([MessageType]::Error)
+
+            return $false
+        }
+
+        $validationData.packageFound = $true
+        $validationData.packageSourceUrl = $chocolateyPage.Links | Where-Object title -match "^See the package source\." | Select-Object -First 1 -ExpandProperty href
+        $validationData.packageMaintainers = $chocolateyPage.Links | Where-Object href -match "\/profiles\/" | Select-Object -ExpandProperty title -Unique | Sort-Object
+    }
+    catch {
+        $validationData.packageFound = $false
+        if (!$validationData.isNewPackageRequest) {
+            Write-WarningMessage ([WarningMessages]::userRequestedNewMaintainer)
+            Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+            Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::packageNotFoundError -f $validationData.packageName) -type ([MessageType]::Error)
+
+            return $false
+        }
+    }
+
+    return $true
+}

--- a/scripts/private/validations/Get-CommunityMaintainerValidationResults.ps1
+++ b/scripts/private/validations/Get-CommunityMaintainerValidationResults.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates the current request using rules for community users
 .PARAMETER issueData

--- a/scripts/private/validations/Get-CommunityMaintainerValidationResults.ps1
+++ b/scripts/private/validations/Get-CommunityMaintainerValidationResults.ps1
@@ -36,7 +36,7 @@ function Get-CommunityMaintainerValidationResults() {
     }
 
     Write-Host ([StatusCheckMessages]::checkUserSuppliedMaintainerContactDate)
-    $re = "Date the maintainer was contacted\s*:\s*(\d{4}-\d{2}-\d{2})"
+    $re = "Date the maintainer was contacted\s*\(in YYYY-MM-DD\)\s*:\s(\d{4}-\d{2}-\d{2})"
     if (!(Compare-Body @compareData -re $re)) {
         Write-WarningMessage ([WarningMessages]::userNotSpecifiedContactDateOfMaintainer)
         Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)

--- a/scripts/private/validations/Get-CommunityMaintainerValidationResults.ps1
+++ b/scripts/private/validations/Get-CommunityMaintainerValidationResults.ps1
@@ -1,0 +1,57 @@
+<#
+.SYNOPSIS
+    Validates the current request using rules for community users
+.PARAMETER issueData
+    The issue data for the current request
+.PARAMETER validationData
+    The validation data storage for the current request
+#>
+function Get-CommunityMaintainerValidationResults() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IssueData]$issueData,
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData
+    )
+
+    $compareData = @{
+        issueData      = $issueData
+        validationData = $validationData
+    }
+
+    Write-Host ([StatusCheckMessages]::checkMarkedAsFollowingTriageProcess)
+    $re = "\[x\]\s*I have followed the Package Triage Process"
+    if (!(Compare-Body @compareData -re $re)) {
+        Write-WarningMessage ([WarningMessages]::userNotSelectedTriageProcessFollowed)
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::triageProcessNotFollowedError) -type ([MessageType]::Error)
+    }
+
+    Write-Host ([StatusCheckMessages]::checkMarkedAsSearchedForIssues)
+    $re = "\[x\]\s*There is no existing open maintainer"
+    if (!(Compare-Body @compareData -re $re)) {
+        Write-WarningMessage ([WarningMessages]::userNotSelectedSearchingForIssues)
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::githubSearchNotMarkedError -f $validationData.repository, $validationData.packageName) -type ([MessageType]::Error)
+    }
+
+    Write-Host ([StatusCheckMessages]::checkUserSuppliedMaintainerContactDate)
+    $re = "Date the maintainer was contacted\s*:\s*(\d{4}-\d{2}-\d{2})"
+    if (!(Compare-Body @compareData -re $re)) {
+        Write-WarningMessage ([WarningMessages]::userNotSpecifiedContactDateOfMaintainer)
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::maintainerContactedDateMissingError) -type ([MessageType]::Error)
+    }
+
+    # TODO Validate contact date being larger than 7 days (maybe)
+
+    Write-Host ([StatusCheckMessages]::checkUserSuppliedMaintainerContactMethod)
+    $re = "How the maintainer was contacted\s*:\s*[a-z]"
+    if (!(Compare-Body @compareData -re $re)) {
+        Write-WarningMessage ([WarningMessages]::userNotSpecifiedContactMethodOfMaintainer)
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::maintainerContactedMethodMissingError) -type ([MessageType]::Error)
+    }
+
+    return $true
+}

--- a/scripts/private/validations/Get-CurrentMaintainerValidationResult.ps1
+++ b/scripts/private/validations/Get-CurrentMaintainerValidationResult.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    Validates the current request using current maintainer rules
+.PARAMETER issueData
+    The issue data for the current request
+.PARAMETER validationData
+    The validation data storage for the current request
+#>
+function Get-CurrentMaintainerValidationResult() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IssueData]$issueData,
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData
+    )
+
+    $userIsKnownMaintainer = $false
+    if (Test-Path "$PSScriptRoot/../../users.json") {
+        $allStoredUsers = Get-Content "$PSScriptRoot/../../users.json" -Encoding utf8NoBOM | ConvertFrom-Json
+        $storedUser = $allStoredUsers | ? github -eq $issueData.userLogin
+        if ($storedUser) {
+            $userIsKnownMaintainer = $validationData.packageMaintainers | ? { $_ -eq $storedUser.choco }
+        }
+    }
+
+    $compareData = @{
+        issueData      = $issueData
+        validationData = $validationData
+    }
+
+    Write-Host ([StatusCheckMessages]::checkMarkedAsCurrentMaintainer)
+    $re = "(?i)\[[\sx]*\]\s*(I am the maintainer of the package)"
+    if ($userIsKnownMaintainer) {
+        if (Compare-Body @compareData -re $re) {
+            Update-ValidationBody -issueData $issueData -validationData $validationData -replacement $re, "[x] `${1}"
+        }
+        else {
+            Write-WarningMessage ([WarningMessages]::userIsKnowMaintainerMissingConfirmationPart)
+            Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+            Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::currentMaintainerCheckboxMissingError) -type ([MessageType]::Error)
+        }
+    }
+    else {
+        if (Compare-Body @compareData -re $re) {
+            Update-ValidationBody -issueData $issueData -validationData $validationData -replacement $re, "[ ] `${1}"
+        }
+
+        Write-WarningMessage ([WarningMessages]::userNotKnownMaintainerOfPackage)
+        if ($allStoredUsers | ? github -eq $issueData.userLogin) {
+            $errMsg = [ValidationMessages]::currentMaintainerNotVerifiedUserIsKnownError
+        }
+        else {
+            $errMsg = [ValidationMessages]::currentMaintainerNotVerifiedUserIsUnknownError
+        }
+
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message $errMsg -type ([MessageType]::Error)
+    }
+
+    # Validate that the template do not contain the date the maintainer was contacted
+    Write-Host ([StatusCheckMessages]::checkUserRemovedMaintainerContactedDate)
+    $re = "(?smi)^Date the maintainer was contacted[^\r\n]*[\r\n]$"
+    if (Compare-Body @compareData -re $re) {
+        Write-WarningMessage ([WarningMessages]::userNotRemovedMaintainerContactedDate)
+        Update-ValidationBody -issueData $issueData -validationData $validationData -replacement $re, ""
+    }
+
+    $re = "(?smi)^How the maintainer was contacted[^\r\n]*[\r\n]$"
+    if (Compare-Body @compareData -re $re) {
+        Update-ValidationBody -issueData $issueData -validationData $validationData -replacement $re, ""
+    }
+
+    if (!($validationData.messages | ? { $_.type -eq [MessageType]::Error -or $_.type -eq [MessageType]::Warning })) {
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::availableRequest)
+    }
+
+    return $true
+}

--- a/scripts/private/validations/Get-CurrentMaintainerValidationResult.ps1
+++ b/scripts/private/validations/Get-CurrentMaintainerValidationResult.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates the current request using current maintainer rules
 .PARAMETER issueData

--- a/scripts/private/validations/Get-NewPackageValidationResult.ps1
+++ b/scripts/private/validations/Get-NewPackageValidationResult.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Validates the current request as a new package request
 .PARAMETER issueData

--- a/scripts/private/validations/Get-NewPackageValidationResult.ps1
+++ b/scripts/private/validations/Get-NewPackageValidationResult.ps1
@@ -1,0 +1,118 @@
+<#
+.SYNOPSIS
+    Validates the current request as a new package request
+.PARAMETER issueData
+    The issue data for the current request
+.PARAMETER validationData
+    The validation data storage for the current request
+#>
+function Get-NewPackageValidationResult() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IssueData]$issueData,
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData
+    )
+
+    $compareData = @{
+        issueData      = $issueData
+        validationData = $validationData
+    }
+
+    $downloadUrl = $null
+
+    Write-Host ([StatusCheckMessages]::checkingUserMarkedChocolateySearched)
+    $re = "\[x\]\s*The package I am req"
+    if (!(Compare-Body @compareData -re $re)) {
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::chocolateySearchNotMarkedError) -type ([MessageType]::Error)
+    }
+
+    Write-Host ([StatusCheckMessages]::checkingUserMarkedDownloadUrlPublic)
+    $re = "\[x\]\s*The download URL is public"
+    if (!(Compare-Body @compareData -re $re)) {
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::downloadUrlPublicMarkedError) -type ([MessageType]::Error)
+    }
+
+    Write-Host ([StatusCheckMessages]::checkUserMarkedWithCorrectRFPTitle)
+    $re = "(?i)\[[\sx]*\]\s*((?:The )?Issue title starts(?: with)? 'RFP)"
+    if ((Compare-Body @compareData -re $re) -and ($issueData.title -match "^RFP" -or $validationData.newTitle -match "^RFP")) {
+        Write-Host ([StatusMessages]::uncheckedRFPItemFound)
+        Update-ValidationBody -issueData $issueData -validationData $validationData -replacement $re, "[x] `${1}"
+    }
+    else {
+        Write-WarningMessage ([WarningMessages]::templateMissingRFPCheckbox)
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::issueMissingRfpCheckboxError) -type ([MessageType]::Error)
+    }
+
+    Write-Host ([StatusCheckMessages]::checkingUserProvidedSoftwareProjectUrl)
+    $re = "(?smi)Software project URL\s*\:[\s\r\n]*(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*))"
+    $m = Compare-Body @compareData -re $re
+    if (!$m) {
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::softwareProjectUrlError) -type ([MessageType]::Error)
+    }
+
+    Write-Host ([StatusCheckMessages]::checkingUserProvidedDirectDownloadUrl)
+    $re = "(?smi)Direct download[^\:]+\:[\s\r\n]*(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*))"
+    $m = Compare-Body @compareData -re $re
+    if (!$m) {
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::softwareDirectDownloadError) -type ([MessageType]::Error)
+    }
+    else {
+        $downloadUrl = $m[1]
+    }
+
+    Write-Host ([StatusCheckMessages]::checkingUserSearchedForOpenIssues)
+    $re = "\[x\]\s*There is no open issue"
+    if (!(Compare-Body @compareData -re $re)) {
+        Update-StatusLabel -validationData $validationData -label ([StatusLabels]::incompleteRequest)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::githubSearchNotMarkedError -f $validationData.repository, ($validationData.packageName -replace ' ', '%20')) -type ([MessageType]::Error)
+    }
+
+    try {
+        if ($downloadUrl) {
+            Write-Host ([StatusCheckMessages]::fileDownloadCheck)
+            Get-RemoteFile -url $downloadUrl -filePath "$env:TEMP/software.tmp"
+
+            Write-Host ([StatusCheckMessages]::fileDownloadCheck)
+            $result = Test-ValidFile "$env:TEMP/software.tmp"
+
+            if ($result -eq "missing") {
+                Write-ErrorMessage ([ErrorMessages]::toolingMissing)
+                return $false
+            }
+            else {
+                if ($result.valid) {
+                    $msg = ""
+                    $msgType = [MessageType]::Info
+                }
+                else {
+                    Write-WarningMessage ([WarningMessages]::fileValidationFailed)
+                    $msg = [ValidationMessages]::fileValidationFailed
+                    $validationData.newLabels += [StatusLabels]::upstreamBlocked
+                    $msgType = [MessageType]::Warning
+                }
+                $msg += "`n<details>`n<summary>File Validation Output</summary>`n`n```````n"
+                $result.output | % { $msg += "$_`n" }
+                $msg += "```````n</details>"
+                Add-ValidationMessage -validationData $validationData -message $msg -type $msgType
+            }
+
+            Remove-Item "$env:TEMP/software.tmp" -ea 0
+        }
+        else {
+            Write-WarningMessage ([WarningMessages]::noDownloadUrlFound)
+        }
+    }
+    catch {
+        Write-WarningMessage ([WarningMessages]::downloadValidationFailed)
+        Add-ValidationMessage -validationData $validationData -message ([ValidationMessages]::fileValidationMaintainerNotice) -type ([MessageType]::Info)
+        $validationData.newLabels += [StatusLabels]::upstreamBlocked
+    }
+
+    return $true
+}

--- a/scripts/private/validations/Update-StatusLabel.ps1
+++ b/scripts/private/validations/Update-StatusLabel.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Updates the status label for the current request
 .DESCRIPTION

--- a/scripts/private/validations/Update-StatusLabel.ps1
+++ b/scripts/private/validations/Update-StatusLabel.ps1
@@ -1,0 +1,29 @@
+<#
+.SYNOPSIS
+    Updates the status label for the current request
+.DESCRIPTION
+    Updates the status label for the current request
+    and stores it to the specified validation data storage.
+.PARAMETER validationData
+    The validation data storage to use
+.PARAMETER label
+    The status label to update to
+#>
+function Update-StatusLabel() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData,
+        [Parameter(Mandatory = $true)]
+        [string]$label
+    )
+
+    if (!$validationData.newLabels -or $validationData.newLabels.Count -eq 0) {
+        $validationData.newLabels = @($label)
+    }
+
+    $existingStatusLabel = $validationData.newLabels | ? { $_ -match "^Status:" }
+
+    if ($existingStatusLabel -ne [StatusLabels]::incompleteRequest) {
+        $validationData.newLabels = ($validationData.newLabels | ? { $_ -ne $existingStatusLabel }) + $label
+    }
+}

--- a/scripts/private/validations/Update-ValidationBody.ps1
+++ b/scripts/private/validations/Update-ValidationBody.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    Updates the body for the current validation request.
+.PARAMETER issueData
+    The issue data for the current request
+.PARAMETER validationData
+    The validation data storage for the current request
+.PARAMETER replacement
+    The regex replacement to perform on the body
+#>
+function Update-ValidationBody {
+    param(
+        [Parameter(Mandatory = $true)]
+        [IssueData]$issueData,
+        [Parameter(Mandatory = $true)]
+        [ValidationData]$validationData,
+        #[Parameter(Mandatory = $true)]
+        [string[]]$replacement
+    )
+
+    $body = $null
+
+    if ($validationData.newBody) {
+        $body = $validationData.newBody -replace $replacement
+    }
+    else {
+        $body = $issueData.body -replace $replacement
+    }
+
+    if ($body -cne $issueData.body) {
+        $validationData.newBody = $body
+    }
+}

--- a/scripts/private/validations/Update-ValidationBody.ps1
+++ b/scripts/private/validations/Update-ValidationBody.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Updates the body for the current validation request.
 .PARAMETER issueData

--- a/scripts/private/validations/ValidationData.ps1
+++ b/scripts/private/validations/ValidationData.ps1
@@ -1,0 +1,24 @@
+enum MessageType {
+    None
+    Error
+    Warning
+    Info # This is for maintainers, not for the requester
+}
+
+class ValidationMessage {
+    [string]$message;
+    [MessageType]$type;
+}
+
+class ValidationData {
+    [string]$newTitle;
+    [string[]]$newLabels;
+    [string]$newBody;
+    [bool]$packageFound;
+    [string]$packageName;
+    [string]$packageSourceUrl;
+    [string[]]$packageMaintainers;
+    [System.Collections.Generic.List[ValidationMessage]]$messages;
+    [bool]$isNewPackageRequest;
+    [string]$repository;
+}

--- a/scripts/private/validations/ValidationData.ps1
+++ b/scripts/private/validations/ValidationData.ps1
@@ -1,4 +1,4 @@
-enum MessageType {
+﻿enum MessageType {
     None
     Error
     Warning

--- a/scripts/public/New-UserConnection.ps1
+++ b/scripts/public/New-UserConnection.ps1
@@ -1,0 +1,116 @@
+﻿<#
+.SYNOPSIS
+    Connect chocolatey user together with a github user.
+.PARAMETER commentId
+    The identifier of the comment that
+    executed this request.
+.PARAMETER repository
+    The repository where this comment is located in.
+#>
+function New-UserConnection {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$commentId,
+        [string]$repository = $env:GITHUB_REPOSITORY
+    )
+
+    $commentData = Get-Comment -commentId $commentId -repository $repository
+    $permissionData = Get-Permission -login $commentData.userLogin -repository $repository
+    $issueNumber = Split-Path -Leaf $commentData.issue_url
+
+    $statusMsgs = ""
+    if (!$permissionData.readAccess) {
+        # I assume the user is banned in this case
+        Submit-Comment -issueNumber $issueNumber -repository $repository -commentBody ([PermissionMessages]::actionDenied -f $permmisionData.login)
+        return
+    }
+
+    [array]$userData = $commentData.body -split "\r?\n" | Select-String "^/attach (?:@(?<githubUser>[^\s\.\,]+)[\.\,\s]*(?<chocoUser>[a-z0-9_\.-]+)|(?<chocoUser>[a-z0-9_\.-]+)[^@]+@(?<githubUser>[^\s\n\r\.\,]+))" -AllMatches | ForEach-Object Matches | ForEach-Object {
+        $githubUser = $_.Groups["githubUser"]
+        if ($githubUser.Value -ne $permissionData.login -and !$permissionData.writeAccess) {
+            $statusMsgs = [PermissionMessages]::userAddDenied -f $permissionData.login
+            return
+        }
+
+        $chocoUser = $_.Groups["chocoUser"]
+        return @{
+            github = $githubUser.Value
+            choco  = $chocoUser.Value
+            type   = 'attached'
+        }
+    }
+
+    if ($statusMsgs) {
+        Submit-Comment -issueNumber $issueNumber -repository $repository -commentBody $statusMsgs
+        return
+    }
+
+    $userData += $commentData.body -split "\r?\n" | Select-String "^/(?:attach|confirm)\s+([a-z0-9_-]+)\s*([\n\r]|$)" -AllMatches | ForEach-Object Matches | ForEach-Object {
+        return @{
+            github = $permissionData.login
+            choco  = $_.Groups[1].Value
+            type   = if ($_.ToString().StartsWith('/confirm')) { "confirmed" } else { "attached" }
+        }
+    } | Select-Object -First 1
+
+    if ($userData.Count -eq 0) {
+        $statusMsgs = [ErrorMessages]::invalidCommand -f $permissionData.login
+        Write-WarningMessage ([ErrorMessages]::invalidCommandException)
+        Submit-Comment -issueNumber $issueNumber -repository $repository -commentBody $statusMsgs
+        return
+    }
+
+    $chocoUrlFormat = "https://chocolatey.org/profiles/{0}"
+
+
+    # TODO validate that current user have permissions to do this command (need write or triage access), unless the user have confirmed
+    # the chocolatey username
+    $existingData = @()
+
+    if (Test-Path "$PSScriptRoot/../users.json") {
+        [array]$existingData = Get-Content -Raw -Encoding utf8NoBOM -Path "$PSScriptRoot/../users.json" | ConvertFrom-Json
+        $existingData | ForEach-Object {
+            if ($userData | Where-Object github -eq $_.github) {
+                $msg = [WarningMessages]::githubUserConnected -f $_.github
+                $statusMsgs = "${statusMsgs}`n$msg"
+                Write-WarningMessage $msg
+                $userData = $userData | Where-Object github -ne $_.github
+            }
+            if ($userData | Where-Object choco -eq $_.choco) {
+                $msg = [WarningMessages]::chocolateyUserConnected -f $_.choco
+                $statusMsgs = "${statusMsgs}`n$msg"
+                Write-WarningMessage $msg
+                $userData = $userData | Where-Object choco -ne $_.choco
+            }
+        }
+    }
+
+    $userData = $userData | Where-Object {
+        try {
+            Invoke-WebRequest ($chocoUrlFormat -f $_.choco) -UseBasicParsing
+            return $true
+        }
+        catch {
+            $msg = [WarningMessages]::chocolateyUserMissing -f $_.choco
+            Write-WarningMessage $msg
+            $statusMsgs = "${statusMsgs}`n$msg"
+            return $false
+        }
+    } | Sort-Object -Property choco, github
+
+    $userData + $existingData | Select-Object -Property choco, github | Sort-Object -Property choco, github | ConvertTo-Json -AsArray | Out-File "$PSScriptRoot/../users.json" -Encoding utf8NoBOM
+
+    $userData | ForEach-Object {
+        $msg = ""
+        if ($_.type -eq 'confirmed') {
+            $msg = [StatusMessages]::chocolateyUserConfirmed -f $_.github, $_.choco
+        }
+        else {
+            $msg = [StatusMessages]::chocolateyUserConnected -f $_.choco, $_.github
+        }
+        $statusMsgs = "$statusMsgs`n$msg"
+        $msg
+    }
+
+    Invoke-Commenting -issueNumber $issueNumber -repository $repository -commentBody $statusMsgs
+}

--- a/scripts/public/Remove-UserConnection.ps1
+++ b/scripts/public/Remove-UserConnection.ps1
@@ -1,0 +1,110 @@
+<#
+.SYNOPSIS
+    Disconnect stored chocolatey/github user.
+.PARAMETER commentId
+    The identifier of the comment that
+    executed this request.
+.PARAMETER repository
+    The repository where this comment is located in.
+#>
+function Remove-UserConnection() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$commentId,
+        [string]$repository = $env:GITHUB_REPOSITORY
+    )
+
+    $commentData = Get-Comment -commentId $commentId -repository $repository
+    $permissionData = Get-Permission -login $commentData.userLogin -repository $repository
+    $issueNumber = Split-Path -Leaf $commentData.issue_url
+
+    if (!$permissionData.readAccess) {
+        # I assume the user is banned in this case
+        Submit-Comment -issueNumber $issueNumber -repository $repository -commentBody ([PermissionMessages]::actionDenied -f $permissionData.login)
+        return
+    }
+
+    $existingData = @()
+
+    if (Test-Path "$PSScriptRoot/../users.json") {
+        "Loading existing users"
+        [array]$existingData = Get-Content -Raw -Encoding utf8NoBOM -Path "$PSScriptRoot/../users.json" | ConvertFrom-Json
+    }
+    
+    if (!$existingData -or $existingData.Count -eq 0) {
+        "No users available, exiting..."
+        # Set us just ignore everything
+        return
+    }
+    
+    "Reiceved comment '$($commentData.body)'"
+
+    $statusMessage = ""
+    $throwError = $false
+
+    $chocoUsers = @()
+    $githubUsers = @()
+
+    $commentData.body -split "\r?\n" | Select-String "^/(?:detach|remove user) (?:@(?<githubUser>[^\s\.\,]+)|(?<chocoUser>[a-z0-9_\.-]+))" -AllMatches | % Matches | % {
+        if ($_.Groups["githubUser"].Success) {
+            $requestedUser = $_.Groups["githubUser"].Value
+            "User requested to remove the github user '@$requestedUser'"
+            if ($requestedUser -ne $permissionData.login -and !$permissionData.writeAccess) {
+                $statusMessage = [PermissionMessages]::userRemoveDenied -f $permissionData.login
+                $throwError = $true
+                "Request was denied..."
+                return
+            }
+            else {
+                $githubUsers += @($_.Groups["githubUser"].Value)
+                "Request was accepted."
+            }
+        }
+        elseif ($_.Groups["chocoUser"].Success) {
+            $requestedUser = $_.Groups["chocoUser"].Value
+            "User requested to remove the chocolatey user '$requestedUser'"
+            $data = $existingData | ? choco -eq $requestedUser
+            if ($data -and $data.github -ne $permissionData.login -and !$permissionData.writeAccess) {
+                $statusMessage = [PermissionMessages]::userRemoveDenied -f $permissionData.login
+                $throwError = $true
+                "Request was denied..."
+                return
+            }
+            else {
+                $chocoUsers += $requestedUser
+                "Request was accepted..."
+            }
+        }
+    }
+
+    if ($commentData.body -match "(?smi)^\/remove user\s*([^@a-z0-9_\.-]|$)") {
+        "Requested user requested to remove themself as known user..."
+        $githubUsers += @($commentData.userLogin)
+    }
+
+    $chocoUsers | % {
+        if (!$throwError) {
+            "Removing chocolatey user '$_'"
+            $existingData = $existingData | ? choco -ne $_
+            $msg = [StatusMessages]::chocolateyUserDisconnected -f $_
+            $statusMessage = "$statusMessage`n$msg"
+        }
+    }
+    $githubUsers | % {
+        if (!$throwError) {
+            "Removing github user '@$_'"
+            $existingData = $existingData | ? github -ne $_
+            $msg = [StatusMessages]::githubUserDisconnected -f $_
+            $statusMessage = "$statusMessage`n$msg"
+        }
+    }
+
+    if ($throwError) {
+        Submit-Comment -issueNumber $issueNumber -repository $repository -commentBody $statusMessage
+    }
+    elseif ($statusMessage) {
+        "Saving new users data"
+        $existingData | Sort-Object -Property choco, github | ConvertTo-Json -AsArray | Out-File "$PSScriptRoot/../users.json" -Encoding utf8NoBOM
+        Invoke-Commenting -issueNumber $issueNumber -repository $repository -commentBody $statusMessage
+    }
+}

--- a/scripts/public/Remove-UserConnection.ps1
+++ b/scripts/public/Remove-UserConnection.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Disconnect stored chocolatey/github user.
 .PARAMETER commentId
@@ -30,13 +30,13 @@ function Remove-UserConnection() {
         "Loading existing users"
         [array]$existingData = Get-Content -Raw -Encoding utf8NoBOM -Path "$PSScriptRoot/../users.json" | ConvertFrom-Json
     }
-    
+
     if (!$existingData -or $existingData.Count -eq 0) {
         "No users available, exiting..."
         # Set us just ignore everything
         return
     }
-    
+
     "Reiceved comment '$($commentData.body)'"
 
     $statusMessage = ""

--- a/scripts/public/Submit-Comment.ps1
+++ b/scripts/public/Submit-Comment.ps1
@@ -1,0 +1,37 @@
+﻿<#
+.SYNOPSIS
+    Small helper to update or add a new comment
+.PARAMETER issueNumber
+    The issue number to create a new comment on
+.PARAMETER commentId
+    The unique identifier of the comment to update
+.PARAMETER repository
+    The repository where the issue/comment is located in
+.PARAMETER commentBody
+    The actualy comment to add/update
+.PARAMETER githubToken
+    The api token to use for authenticated requests
+.OUTPUTS
+    The updated/added comment data
+#>
+function Submit-Comment {
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = "New Issue")]
+        [int]$issueNumber,
+        [Parameter(Mandatory = $true, ParameterSetName = "Update Issue")]
+        [int]$commentId,
+        [Parameter(Mandatory = $true)]
+        [string]$repository,
+        [Parameter(Mandatory = $true)]
+        [string]$commentBody,
+
+        [string]$githubToken = $env:GITHUB_TOKEN
+    )
+
+    if ($commentId) {
+        return Update-Comment -commentId $commentId -repository $repository -commentBody $commentBody -githubToken $githubToken
+    }
+    else {
+        return Add-Comment -issueNumber $issueNumber -repository $repository -commentBody $commentBody -githubToken $githubToken
+    }
+}

--- a/scripts/public/Test-NewIssue.ps1
+++ b/scripts/public/Test-NewIssue.ps1
@@ -1,0 +1,140 @@
+﻿$ErrorActionPreference = 'Stop'
+
+<#
+.SYNOPSIS
+    Runs a full validation check on the current request
+.PARAMETER issueNumber
+    The issue number to run the validation on
+.PARAMETER commentId
+    The unique identifier of the comment that initiated
+    a new validation check
+.PARAMETER repository
+    The repository the validation check should be run on.
+#>
+function Test-NewIssue {
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = "issue")]
+        [int]$issueNumber,
+        [Parameter(Mandatory = $true, ParameterSetName = "comment")]
+        [int]$commentId,
+        [string]$repository = $env:GITHUB_REPOSITORY
+    )
+
+    if ($commentId) {
+        $commentData = Get-Comment -commentId $commentId -repository $repository
+        $issueData = Get-Issue -issueUrl $commentData.issue_url
+    }
+    else {
+        $issueData = Get-Issue -issueNumber $issueNumber -repository $repository
+    }
+
+    if ($issueData.assignees.Count -gt 0) {
+        Write-Host ([StatusMessages]::userAssignedToIssue)
+
+        if ($commentId) {
+            $msg = [PermissionMessages]::issueUserAssigned -f $commentData.userLogin
+            Submit-Comment -issueNumber $issueData.number -repository $repository -commentBody $msg
+        }
+        return
+    }
+
+    $statusLabels = $issuedata.labels | Where-Object { $_ -match "^$([StatusLabels]::statusLabelPrefix)" }
+    if ($statusLabels | Where-Object { -not ($_ -eq [StatusLabels]::triageRequest -or $_ -eq [StatusLabels]::incompleteRequest) }) {
+        Write-Host ([StatusMessages]::issueHaveBeenLabeled)
+
+        $msg = [PermissionMessages]::issueLabelAssigned -f $commentData.userLogin, ([StatusLabels]::triageRequest), ([StatusLabels]::incompleteRequest)
+        Submit-Comment -issueNumber $issueData.number -repository $repository -commentBody $msg
+        return
+    }
+    $validationData = [ValidationData]::new()
+    $validationData.repository = $repository
+    Update-StatusLabel -validationData $validationData -label ([StatusLabels]::triageRequest)
+
+    $arguments = @{
+        issueData      = $issueData
+        validationData = $validationData
+    }
+
+    $result = Get-CommonValidationResults @arguments
+
+    Format-Checkboxes @arguments
+
+    if ($result -and $arguments.validationData.isNewPackageRequest) { $result = Get-NewPackageValidationResult @arguments }
+    if ($result -and !$arguments.validationData.isNewPackageRequest) { $result = Get-CommonMaintainerValidationResult @arguments }
+
+    if ($result) {
+        Write-Host ([StatusCheckMessages]::checkingForExistingIssues -f $validationData.packageName)
+        $existingIssues = Search-Issues -query "repo:$($validationData.repository)+state:open+in:title $($validationData.packageName)" -repository $validationData.repository | Where-Object number -ne $issueData.number
+        if ($existingIssues) {
+            $existing = ($existingIssues | ForEach-Object { "[$($_.title)]($($_.html_url))" } ) -join ", "
+
+            $noticeMsg = [ValidationMessages]::issuesFoundNotice -f $existing
+
+            Update-StatusLabel -validationData $validationData -label ([StatusLabels]::triageRequest)
+            Add-ValidationMessage -validationData $validationData -message $noticeMsg -type ([MessageType]::Warning)
+        }
+    }
+
+
+    $arguments = @{
+        issueUrl = $issueData.url
+    }
+
+    $arguments["labels"] = [array]($existingLabels + $validationData.newLabels) | Select-Object -Unique
+
+    if ($validationData.newBody -and $validationData.newBody -cne $issueData.body) {
+        $arguments["description"] = $validationData.newBody
+    }
+    if ($validationData.newTitle -and $validationData.newTitle -cne $issueData.title) {
+        $arguments["title"] = $validationData.newTitle
+    }
+
+    $issueData = Update-Issue @arguments
+
+
+    $commentBody = [ValidationMessages]::commentBodyDetection + "`n" + [ValidationMessages]::commentBodyHeader
+
+    if (!($validationData.messages | Where-Object type -NE ([MessageType]::Info))) {
+        if ($validationData.newLabels.Contains([StatusLabels]::availableRequest)) {
+            $commentBody += "`n`n" + [ValidationMessages]::availableSuccess
+        }
+        else {
+            $commentBody += "`n`n" + [ValidationMessages]::triageSuccess
+        }
+    }
+    else {
+        $errors = $validationData.messages | Where-Object type -EQ ([MessageType]::Error)
+        if ($errors) {
+            $commentBody += "`n`n" + [ValidationMessages]::errorsHeader
+            $errors | ForEach-Object {
+                $commentBody += "`n- $($_.message)"
+            }
+        }
+        $warnings = $validationData.messages | Where-Object type -EQ ([MessageType]::Warning)
+        if ($warnings) {
+            $commentBody += "`n`n" + [ValidationMessages]::noticesHeader
+            $warnings | ForEach-Object {
+                $commentBody += "`n- $($_.message)"
+            }
+        }
+    }
+
+    $infos = $validationData.messages | Where-Object type -EQ ([MessageType]::Info)
+    if ($infos) {
+        $commentBody += "`n`n" + [ValidationMessages]::maintainersHeader
+        $infos | ForEach-Object {
+            $commentBody += "`n- $($_.message)"
+        }
+    }
+
+    $commentBody += [ValidationMessages]::commentBodyFooter
+
+    Write-Host ([StatusCheckMessages]::checkingExistingValidationComment)
+    $commentsData = Get-Comment -issueNumber $issueData.number -contentMatch ([regex]::Escape([ValidationMessages]::commentBodyDetection)) -repository $repository
+
+    if ($commentsData) {
+        Remove-Comment $commentsData.id -repository $repository
+    }
+
+    Add-Comment -issueNumber $issueData.number -repository $repository -commentBody $commentBody
+}

--- a/scripts/users.json
+++ b/scripts/users.json
@@ -1,0 +1,34 @@
+[
+  {
+    "choco": "admiringworm",
+    "github": "AdmiringWorm"
+  },
+  {
+    "choco": "chocolatey",
+    "github": "choco-bot"
+  },
+  {
+    "choco": "dtgm",
+    "github": "dtgm"
+  },
+  {
+    "choco": "ferventcoder",
+    "github": "ferventcoder"
+  },
+  {
+    "choco": "gep13",
+    "github": "gep13"
+  },
+  {
+    "choco": "majkinetor",
+    "github": "majkinetor"
+  },
+  {
+    "choco": "mkevenaar",
+    "github": "mkevenaar"
+  },
+  {
+    "choco": "pauby",
+    "github": "pauby"
+  }
+]

--- a/scripts/validation.psm1
+++ b/scripts/validation.psm1
@@ -3,10 +3,10 @@
 $paths = "private", "public"
 foreach ($path in $paths) {
     Get-ChildItem $PSScriptRoot\$path\*.ps1 -Recurse | ForEach-Object {
-        Write-Host "Importing file $_"
+        Write-Verbose "Importing file $_"
         . $_
         if ($path -eq "public") {
-            Write-Host "Exporting member $($_.BaseName)"
+            Write-Verbose "Exporting member $($_.BaseName)"
             Export-ModuleMember -Function $_.BaseName
         }
     }

--- a/scripts/validation.psm1
+++ b/scripts/validation.psm1
@@ -1,4 +1,4 @@
-#requires -version "7.0"
+﻿#requires -version "7.0"
 
 $paths = "private", "public"
 foreach ($path in $paths) {

--- a/scripts/validation.psm1
+++ b/scripts/validation.psm1
@@ -1,0 +1,13 @@
+#requires -version "7.0"
+
+$paths = "private", "public"
+foreach ($path in $paths) {
+    Get-ChildItem $PSScriptRoot\$path\*.ps1 -Recurse | ForEach-Object {
+        Write-Host "Importing file $_"
+        . $_
+        if ($path -eq "public") {
+            Write-Host "Exporting member $($_.BaseName)"
+            Export-ModuleMember -Function $_.BaseName
+        }
+    }
+}


### PR DESCRIPTION
This pull request implements some validations that run when a user opens or edits an issue on the package request repository.

These validations include, but is not limited to:
- Validate that the title has been prefixed with either RFM or RFP (wrong formatting will be updated in some cases)
- Validates that all necessary checkboxes have been marked (the validator will mark some if they haven't been, like the one mentioning if the title is starting with RFM/RFP)
- For RFM Requests
  - Validate that not `Current Maintainer` AND `I DON'T WANT TO become the maintainer` are both used.
  - Validate that when `Current Maintainer` part of the template that the user opening the request has been confirmed as the maintainer of the chocolatey package.
  - For Current maintainers, it will remove the date and method the maintainer was contacted (since these are not necessary when the requester is the current maintainer)
  - For NOT current maintainers, it will verify that the user has specified the date and method the current maintainer has been tried to be contacted.
  - Automatically includes the package URL if a package matching the issue title is found (otherwise, it request changes).
  - Automatically adds the package source URL if the latest version of the package contains one, otherwise outputs a notice about one not being found.
- For RFP Requests
  - Will validate that there is no package on chocolatey.org that matches the specified issue title.
  - Validates that a software project URL has been specified
  - Validates that a direct download URL is specified, can be downloaded and is of an accepted type (executables and archives currently).

There are other validations than the ones mentioned above, but those are the gist of them.

Additionally, this pull request adds a few commands that can be used to control the validator.

- For any user (unless they are banned):
`/confirm chocolatey-username` - This allows a user to confirm that they are the maintainer of a package, and his/her GitHub username will be attached to their chocolatey username (so this is only needed to be done once). (`/attach chocolatey-username` can be used as an alias
- `/remove user` - This allows a user to remove the attached GitHub username from the repository
- `/recheck` - This allows anyone to re-run the validator at almost any time (This may be locked down to the user opening the issue, and to users with write access in the future)

Additionally, a few more commands are available for users with write access to the repository:

- `/attach @githubUser chocolatey-user`/`/attach chocolatey-user @githubUser` - Allows attaching users other than themself with a specific chocolatey user
- `/detach @githubUser`/`/detach chocolatey-user` - Allows removing a GitHub or chocolatey user from the list of known maintainers (`/remove user @githubUser`/`/remove user chocolatey-user` can be used as an alias)

There are additional commands planned and a status checker for the issue as well. But that is for part 2 that will come at a later date