### PR TITLE
Add ability to check issues against Virus Total

### DIFF
--- a/.github/workflows/handle-comments.yml
+++ b/.github/workflows/handle-comments.yml
@@ -54,6 +54,7 @@ jobs:
     needs: comments
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VIRUS_TOTAL_API_KEY: ${{ secrets.VIRUS_TOTAL_API_KEY }}
       COMMENT_BODY: ${{ github.event.comment.body }}
       # Becasue comment steps take way shorter time than installing
       # packages, we can run these in parallel

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: windows-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VIRUS_TOTAL_API_KEY: ${{ secrets.VIRUS_TOTAL_API_KEY }}
 
     steps:
       - uses: actions/checkout@v2.2.0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true
+}

--- a/scripts/private/api/virus-total/Get-VirusTotalResults.ps1
+++ b/scripts/private/api/virus-total/Get-VirusTotalResults.ps1
@@ -49,10 +49,12 @@ function Get-VirusTotalResults {
 
         Write-Host ([StatusMessages]::virusTotalResultsAvailable)
 
+        [int]$antiVirusCount = $stats.malicious + $stats.suspecious + $stats.harmless + $stats.undetected + $stats.timeout + $stats.failure + $stats.'confirmed-timout'
+
         @{
             Status     = "Found"
             Flagged    = ($stats.malicious + $stats.suspecious)
-            TotalCount = $response.data.attributes.last_analysis_results.Count - $stats.'type-unsupported'
+            TotalCount = $antiVirusCount
             Url        = "https://www.virustotal.com/gui/file/{0}" -f $checksum
         }
     }

--- a/scripts/private/api/virus-total/Get-VirusTotalResults.ps1
+++ b/scripts/private/api/virus-total/Get-VirusTotalResults.ps1
@@ -1,0 +1,70 @@
+function Get-JsonResults() {
+    param(
+        $inputObject
+    )
+
+    try {
+        # we first try normal serialization
+        return $inputObject | ConvertFrom-Json
+    }
+    catch {}
+
+    try {
+        # next we try to serialize as hash table
+        return $inputObject | ConvertFrom-Json -AsHashtable
+    }
+    catch {}
+
+    # at the end we just return the object as is
+    $inputObject
+}
+
+function Get-VirusTotalResults {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$filePath
+    )
+
+    if (!(Test-Path Env:\VIRUS_TOTAL_API_KEY)) {
+        return @{
+            Status     = "NoApiKey"
+            Flagged    = 0
+            TotalCount = 0
+            Url        = $null
+        }
+    }
+
+    Write-Host ([StatusCheckMessages]::virusTotalCheck)
+    $checksum = (Get-FileHash $filePath -Algorithm SHA256 | % Hash).ToLowerInvariant()
+    $apiUrl = "https://www.virustotal.com/api/v3/files/{0}" -f $checksum
+    $headers = @{
+        "x-apikey" = $env:VIRUS_TOTAL_API_KEY
+    }
+
+    try {
+        $response = Invoke-RestMethod -UseBasicParsing -Uri $apiUrl -Method Get -Headers $headers
+        $response = Get-JsonResults -inputObject $response
+
+        $stats = $response.data.attributes.last_analysis_stats
+
+        Write-Host ([StatusMessages]::virusTotalResultsAvailable)
+
+        @{
+            Status     = "Found"
+            Flagged    = ($stats.malicious + $stats.suspecious)
+            TotalCount = $response.data.attributes.last_analysis_results.Count - $stats.'type-unsupported'
+            Url        = "https://www.virustotal.com/gui/file/{0}" -f $checksum
+        }
+    }
+    catch {
+        # We will assume this means that no virus results are available.
+        # VirusTotal seems to return 404 when none are uploaded
+        Write-Host ([StatusMessages]::noVirusTotalStatusAvailable)
+        @{
+            Status     = "NotFound"
+            Flagged    = 0
+            TotalCount = 0
+            Url        = "https://www.virustotal.com/gui/file/{0}" -f $checksum
+        }
+    }
+}

--- a/scripts/private/messages.ps1
+++ b/scripts/private/messages.ps1
@@ -38,6 +38,7 @@ class StatusCheckMessages {
     static [string]$fileDownloadCheck = "Downloading file from direct download URL for testing.";
     static [string]$fileDownloadedTest = "Testing downloaded file";
     static [string]$issueUsesRFPOrRFMTitle = "Checking if user have prefixed title withe RFP or RFM";
+    static [string]$virusTotalCheck = "Checking for virus total results";
 }
 
 class StatusMessages {
@@ -60,6 +61,8 @@ class StatusMessages {
     static [string]$userNotMarkedRFPTitleCorrectly = "User have not marked that he/she have prefixed the issue title with RFP";
     static [string]$userNotProvidedPackageSourceUrl = "User seems to not have provided any URL to the package source (or one do not exist).";
     static [string]$userNotProvidedPackageUrl = "User seems to not have provided any URL to the package";
+    static [string]$noVirusTotalStatusAvailable = "No virus total results are available";
+    static [string]$virusTotalResultsAvailable = "Found virus check results"
 }
 
 class StatusLabels {
@@ -129,6 +132,11 @@ class ValidationMessages {
     static [string]$maintainerContactedDateMissingError = "We could not detect when you contacted the maintainer. Please add this information to the *'Date the maintainer was contacted:'* part of the template in the format of ``year-month-day`` (example with current date ``$(Get-Date -Format 'yyy-MM-dd')``.";
     static [string]$maintainerContactedMethodMissingError = "We could not detect how you contacted the maintainer. Please add this information to the `'How the maintainer was contacted'* part of the template.";
     static [string]$triageProcessNotFollowedError = "We could not detect that you have completed the Package Triage Process for this request. Please head over to the [Package Triage Process documentation](https://chocolatey.org/docs/package-triage-process#the-triage-process) and come back to this request when you have completed the process.";
+
+    # Virus total messages, only informational messages
+    static [string]$noVirusTotalResults = "There are no virus total results available for this software.";
+    static [string]$virusTotalResultsCount = "{0}/{1} anti-virus softwares flagged this software on [VirusTotal]({2})";
+    static [string]$virusTotalResultsNone = "No anti-virus softwares have flagged this software on [VirusTotal]({0})";
 }
 
 class WarningMessages {

--- a/scripts/public/Test-NewIssue.ps1
+++ b/scripts/public/Test-NewIssue.ps1
@@ -133,18 +133,35 @@ function Test-NewIssue {
         $warnings = $validationData.messages | Where-Object type -EQ ([MessageType]::Warning)
         if ($warnings) {
             $commentBody += "`n`n" + [ValidationMessages]::noticesHeader
+            $detailsComment = ""
             $warnings | ForEach-Object {
-                $commentBody += "`n- $($_.message)"
+                # When using the <details> section, special handling is needed
+                if ($_.message -match "\<details\>") {
+                    $detailsComment = $_.message
+                }
+                else {
+                    $commentBody += "`n- $($_.message)"
+                }
             }
+            $commentBody += "`n`n$detailsComment"
         }
     }
 
     $infos = $validationData.messages | Where-Object type -EQ ([MessageType]::Info)
     if ($infos) {
         $commentBody += "`n`n" + [ValidationMessages]::maintainersHeader
+        $detailsComment = ""
         $infos | ForEach-Object {
-            $commentBody += "`n- $($_.message)"
+            # When using the <details> section, special handling is needed
+            if ($_.message -match "\<details\>") {
+                $detailsComment = $_.message
+            }
+            else {
+                $commentBody += "`n- $($_.message)"
+            }
         }
+
+        $commentBody += "`n`n$detailsComment"
     }
 
     $commentBody += [ValidationMessages]::commentBodyFooter

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,4 +1,0 @@
-Remove-Module "validation" -Force
-Import-Module "$PSScriptRoot\validation.psm1"
-
-Test-NewIssue -issueNumber 59 -repository "AdmiringWorm/chocolatey-package-requests" -DryRun

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,4 @@
+Remove-Module "validation" -Force
+Import-Module "$PSScriptRoot\validation.psm1"
+
+Test-NewIssue -issueNumber 59 -repository "AdmiringWorm/chocolatey-package-requests" -DryRun


### PR DESCRIPTION
This pull requests adds the ability to check if there are already virus reports available on VirusTotal for the specified download url.
If there is no report available, it will add to the comment details as such.

This code requires that a `secret` variable is added to the Settings page of this repository called `VIRUS_TOTAL_API_KEY`, and needs to be added by someone with access to a VirusTotal api key and the repository settings page.
